### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Set default behaviour, in case users don't have core.autocrlf set.
+* text=auto !eol
+
+# Scripts
+*.bat               text eol=crlf
+*.sh                text eol=lf


### PR DESCRIPTION
Ensure .sh scripts have LF and .bat scripts have CRLF in the working directory.
Avoid conversion of Unix scripts to CRLF when checking out with `core.autocrlf=true`, on Windows, what may cause (Unix) shell failures.