### PR TITLE
Fix missing include

### DIFF
--- a/include/boost/histogram/detail/axes.hpp
+++ b/include/boost/histogram/detail/axes.hpp
@@ -11,6 +11,7 @@
 #include <boost/assert.hpp>
 #include <boost/histogram/axis/traits.hpp>
 #include <boost/histogram/axis/variant.hpp>
+#include <boost/histogram/detail/make_default.hpp>
 #include <boost/histogram/detail/static_if.hpp>
 #include <boost/histogram/fwd.hpp>
 #include <boost/mp11/algorithm.hpp>


### PR DESCRIPTION
`make_default` is used in this file, but was not included, causing this to break if `make_default.hpp` was not included before it somewhere.