### PR TITLE
Fixing missing inline, adding link test

### DIFF
--- a/include/boost/histogram/detail/fill_n.hpp
+++ b/include/boost/histogram/detail/fill_n.hpp
@@ -259,7 +259,7 @@ void fill_n_check_extra_args(std::size_t n, Ts&&... ts) {
   fold(check(ts)...);
 }
 
-void fill_n_check_extra_args(std::size_t) noexcept {}
+inline void fill_n_check_extra_args(std::size_t) noexcept {}
 
 template <class S, class A, class T, class... Us>
 void fill_n(const std::size_t offset, S& storage, A& axes,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -102,6 +102,8 @@ boost_test(TYPE run SOURCES unlimited_storage_test.cpp
   LIBRARIES Boost::histogram Boost::core)
 boost_test(TYPE run SOURCES utility_test.cpp
   LIBRARIES Boost::histogram Boost::core)
+boost_test(TYPE link SOURCES link_2_test.cpp link_1_test.cpp
+  LIBRARIES Boost::histogram Boost::core)
 
 if (cxx_std_17 IN_LIST CMAKE_CXX_COMPILE_FEATURES)
   boost_test(TYPE run SOURCES deduction_guides_test.cpp

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -69,6 +69,11 @@ alias cxx17 :
     [ requires cpp_deduction_guides ]
     ;
 
+# Verify that the compile succeeds when linking (missing inline detection) 
+alias compiles :
+    [ link link_2_test.cpp link_1_test.cpp ]
+    ;
+
 # check that useful error messages are produced when library is used incorrectly
 alias failure :
     [ compile-fail axis_category_fail0.cpp ]
@@ -113,11 +118,12 @@ alias libserial :
     ;
 
 # skipping "failure", since expected failure messages during debugging are confusing
-alias all : cxx14 cxx17 threading accumulators range units serialization ;
-alias minimal : cxx14 cxx17 threading ;
+alias all : cxx14 cxx17 compiles threading accumulators range units serialization ;
+alias minimal : cxx14 cxx17 compiles threading ;
 
 explicit cxx14 ;
 explicit cxx17 ;
+explicit compiles;
 explicit failure ;
 explicit threading ;
 explicit accumulators ;

--- a/test/link_1_test.cpp
+++ b/test/link_1_test.cpp
@@ -1,0 +1,8 @@
+#include <boost/histogram.hpp>
+#include <boost/histogram/axis/ostream.hpp>
+#include <boost/histogram/ostream.hpp>
+
+// All files should be include above
+
+// Simple do-nothing function, used to keep the compiler from throwing away this file
+int do_nothing() { return 7; }

--- a/test/link_2_test.cpp
+++ b/test/link_2_test.cpp
@@ -1,0 +1,24 @@
+// Copyright 2018 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/core/lightweight_test.hpp>
+
+#include <boost/histogram.hpp>
+#include <boost/histogram/axis/ostream.hpp>
+#include <boost/histogram/ostream.hpp>
+
+// All files should be included above
+
+int do_nothing();
+
+// Verifies there are no functions with missing inline
+int main() {
+
+  int a = do_nothing();
+  BOOST_TEST_EQ(a, 7);
+
+  return boost::report_errors();
+}


### PR DESCRIPTION
There is an inline missing in one of the recent updates, which makes Boost.Histogram unusable when linking two files. I've added a test that fails if this happens again, and fixed the issue.