### PR TITLE
Adding empty(hist, cov)

### DIFF
--- a/include/boost/histogram/algorithm.hpp
+++ b/include/boost/histogram/algorithm.hpp
@@ -12,6 +12,7 @@
   Includes all algorithm headers of the Boost.Histogram library.
 */
 
+#include <boost/histogram/algorithm/empty.hpp>
 #include <boost/histogram/algorithm/project.hpp>
 #include <boost/histogram/algorithm/reduce.hpp>
 #include <boost/histogram/algorithm/sum.hpp>

--- a/include/boost/histogram/algorithm/empty.hpp
+++ b/include/boost/histogram/algorithm/empty.hpp
@@ -1,0 +1,36 @@
+// Copyright 2019 Henry Schreiner
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_HISTOGRAM_ALGORITHM_EMPTY_HPP
+#define BOOST_HISTOGRAM_ALGORITHM_EMPTY_HPP
+
+#include <boost/histogram/fwd.hpp>
+#include <boost/histogram/indexed.hpp>
+
+namespace boost {
+namespace histogram {
+namespace algorithm {
+/** Check to see if all histogram cells are empty. Use coverage to include or
+  exclude the underflow/overflow bins.
+
+  This algorithm has O(N) complexity, where N is the number of cells.
+
+  Returns true if all cells are empty, and false otherwise.
+ */
+template <class A, class S>
+auto empty(const histogram<A, S>& h, coverage cov) {
+  using value_type = typename histogram<A, S>::value_type;
+  const value_type default_value = value_type();
+  for (auto&& ind : indexed(h, cov)) {
+    if (*ind != default_value) { return false; }
+  }
+  return true;
+}
+} // namespace algorithm
+} // namespace histogram
+} // namespace boost
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -62,6 +62,8 @@ boost_test(TYPE run SOURCES algorithm_reduce_test.cpp
   LIBRARIES Boost::histogram Boost::core)
 boost_test(TYPE run SOURCES algorithm_sum_test.cpp
   LIBRARIES Boost::histogram Boost::core)
+boost_test(TYPE run SOURCES algorithm_empty_test.cpp
+  LIBRARIES Boost::histogram Boost::core)
 boost_test(TYPE run SOURCES axis_category_test.cpp
   LIBRARIES Boost::histogram Boost::core)
 boost_test(TYPE run SOURCES axis_integer_test.cpp

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -42,6 +42,7 @@ alias cxx14 :
     [ run algorithm_project_test.cpp ]
     [ run algorithm_reduce_test.cpp ]
     [ run algorithm_sum_test.cpp ]
+    [ run algorithm_empty_test.cpp ]
     [ run axis_category_test.cpp ]
     [ run axis_integer_test.cpp ]
     [ run axis_option_test.cpp ]

--- a/test/algorithm_empty_test.cpp
+++ b/test/algorithm_empty_test.cpp
@@ -38,8 +38,8 @@ void run_tests() {
   auto h2 = make_s(Tag(), std::vector<double>(), ax, ax);
   BOOST_TEST(empty(h2, coverage::all));
   BOOST_TEST(empty(h2, coverage::inner));
-  for (unsigned i = -1; i < 11; ++i) {
-    for (unsigned j = -1; j < 11; ++j) {
+  for (int i = -1; i < 11; ++i) {
+    for (int j = -1; j < 11; ++j) {
       h2.reset();
       h2(i, j);
       BOOST_TEST(!empty(h2, coverage::all));

--- a/test/algorithm_empty_test.cpp
+++ b/test/algorithm_empty_test.cpp
@@ -44,7 +44,7 @@ void run_tests() {
       h2(i, j);
       BOOST_TEST(!empty(h2, coverage::all));
 
-      if ((i == -1 || i == 10) && (j == -1 || j == 10)) {
+      if ((i == -1 || i == 10) || (j == -1 || j == 10)) {
         BOOST_TEST(empty(h2, coverage::inner));
       } else {
         BOOST_TEST(!empty(h2, coverage::inner));

--- a/test/algorithm_empty_test.cpp
+++ b/test/algorithm_empty_test.cpp
@@ -1,0 +1,117 @@
+// Copyright 2018 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <array>
+#include <boost/core/lightweight_test.hpp>
+#include <boost/histogram/accumulators/weighted_mean.hpp>
+#include <boost/histogram/algorithm/empty.hpp>
+#include <boost/histogram/axis/integer.hpp>
+#include <unordered_map>
+#include <vector>
+#include "throw_exception.hpp"
+#include "utility_histogram.hpp"
+
+using namespace boost::histogram;
+using boost::histogram::algorithm::empty;
+
+template <typename Tag>
+void run_tests() {
+  auto ax = axis::integer<>(0, 10);
+
+  auto h1 = make(Tag(), ax);
+  BOOST_TEST(empty(h1, coverage::all));
+  BOOST_TEST(empty(h1, coverage::inner));
+  for (int i = -1; i < 11; ++i) {
+    h1.reset();
+    h1(i);
+    BOOST_TEST(!empty(h1, coverage::all));
+    if (i == -1 || i == 10) {
+      BOOST_TEST(empty(h1, coverage::inner));
+    } else {
+      BOOST_TEST(!empty(h1, coverage::inner));
+    }
+  }
+
+  auto h2 = make_s(Tag(), std::vector<double>(), ax, ax);
+  BOOST_TEST(empty(h2, coverage::all));
+  BOOST_TEST(empty(h2, coverage::inner));
+  for (unsigned i = -1; i < 11; ++i) {
+    for (unsigned j = -1; j < 11; ++j) {
+      h2.reset();
+      h2(i, j);
+      BOOST_TEST(!empty(h2, coverage::all));
+
+      if ((i == -1 || i == 10) && (j == -1 || j == 10)) {
+        BOOST_TEST(empty(h2, coverage::inner));
+      } else {
+        BOOST_TEST(!empty(h2, coverage::inner));
+      }
+    }
+  }
+
+  /* BROKEN, SEE https://github.com/boostorg/histogram/issues/244
+  auto h3 = make_s(Tag(), std::array<int, 12>(), ax);
+  BOOST_TEST(empty(h3, coverage::all));
+  BOOST_TEST(empty(h3, coverage::inner));
+  h3(-2);
+  BOOST_TEST(!empty(h3, coverage::all));
+  BOOST_TEST(empty(h3, coverage::inner));
+  h3(2);
+  BOOST_TEST(!empty(h3, coverage::all));
+  BOOST_TEST(!empty(h3, coverage::inner));
+  */
+
+  auto h4 = make_s(Tag(), std::unordered_map<std::size_t, int>(), ax);
+  BOOST_TEST(empty(h4, coverage::all));
+  BOOST_TEST(empty(h4, coverage::inner));
+  h4(-2);
+  BOOST_TEST(!empty(h4, coverage::all));
+  BOOST_TEST(empty(h4, coverage::inner));
+  h4(2);
+  BOOST_TEST(!empty(h4, coverage::all));
+  BOOST_TEST(!empty(h4, coverage::inner));
+
+  auto h5 = make_s(Tag(), std::vector<accumulators::weighted_sum<>>(),
+                   axis::integer<>(0, 10), axis::integer<>(0, 10));
+  BOOST_TEST(empty(h5, coverage::all));
+  BOOST_TEST(empty(h5, coverage::inner));
+  h5.reset();
+  h5(weight(2), -2, -4);
+  BOOST_TEST(!empty(h5, coverage::all));
+  BOOST_TEST(empty(h5, coverage::inner));
+  h5.reset();
+  h5(weight(1), -4, 2);
+  BOOST_TEST(!empty(h5, coverage::all));
+  BOOST_TEST(empty(h5, coverage::inner));
+  h5.reset();
+  h5(weight(3), 3, 5);
+  BOOST_TEST(!empty(h5, coverage::all));
+  BOOST_TEST(!empty(h5, coverage::inner));
+
+  auto h6 = make_s(Tag(), std::vector<accumulators::weighted_mean<>>(),
+                   axis::integer<>(0, 10), axis::integer<>(0, 10));
+  BOOST_TEST(empty(h6, coverage::all));
+  BOOST_TEST(empty(h6, coverage::inner));
+  h6.reset();
+  h6(weight(2), -2, -4);
+  BOOST_TEST(!empty(h6, coverage::all));
+  BOOST_TEST(empty(h6, coverage::inner));
+  h6.reset();
+  h6(weight(1), -4, 2);
+  BOOST_TEST(!empty(h6, coverage::all));
+  BOOST_TEST(empty(h6, coverage::inner));
+  h6.reset();
+  h6(weight(3), 3, 5);
+  BOOST_TEST(!empty(h6, coverage::all));
+  BOOST_TEST(!empty(h6, coverage::inner));
+}
+
+int main() {
+  run_tests<static_tag>();
+  run_tests<dynamic_tag>();
+
+  return boost::report_errors();
+}


### PR DESCRIPTION
This closes #241. I did not select a default for coverage, and I was not able to add one test that I wanted to due to bug #244 (not related to this PR, though).