### PR TITLE
[Fix] add language feature-macro for <span> for detail::span

### DIFF
--- a/include/boost/histogram/detail/span.hpp
+++ b/include/boost/histogram/detail/span.hpp
@@ -8,7 +8,8 @@
 #define BOOST_HISTOGRAM_DETAIL_SPAN_HPP
 
 #if __cpp_constexpr >= 201603 && __cpp_deduction_guides >= 201703 && \
-    __cpp_lib_nonmember_container_access >= 201411 && __has_include(<span>)
+    __cpp_lib_nonmember_container_access >= 201411 && \
+    __cpp_lib_span >= 201902 && __has_include(<span>)
 #include <span>
 
 namespace boost {


### PR DESCRIPTION
This commit fixes an issue with newer clang/libc++-versions supporting C++2a.
When compiling in C++17 (or earlier) mode, the compiler and libc++ do not expose
the `<span>` include. The logic for `detail::span` to include `<span>`
instead of providing an own implementation does only check if the
include `<span>` exists. It exists, but it is not exposed.
Therefore the compilation fails without this fix complaining about the missing `span`.

Fixes #270 