### PR TITLE
fix: Boolean axis missing options() method

### DIFF
--- a/include/boost/histogram/axis/boolean.hpp
+++ b/include/boost/histogram/axis/boolean.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/core/nvp.hpp>
 #include <boost/histogram/axis/iterator.hpp>
+#include <boost/histogram/axis/option.hpp>
 #include <boost/histogram/axis/metadata_base.hpp>
 #include <boost/histogram/detail/relaxed_equal.hpp>
 #include <boost/histogram/detail/replace_type.hpp>
@@ -38,6 +39,8 @@ public:
   index_type size() const noexcept { return 2; }
 
   static constexpr bool inclusive() noexcept { return true; }
+
+  static constexpr unsigned options() noexcept { return option::none_t::value; }
 
   template <class M>
   bool operator==(const boolean<M>& o) const noexcept {

--- a/test/axis_boolean_test.cpp
+++ b/test/axis_boolean_test.cpp
@@ -36,6 +36,8 @@ int main() {
     BOOST_TEST_EQ(a.index(1), 1);
     BOOST_TEST_EQ(a.index(0), 0);
 
+    BOOST_TEST_EQ(a.options(), axis::option::none_t::value);
+
     BOOST_TEST_CSTR_EQ(str(a).c_str(), "boolean(metadata=\"foo\")");
 
     axis::boolean<> b;


### PR DESCRIPTION
The new boolean axis is missing an `options()` method, which causes it to break in code that expects all axes to have an options method (boost-histogram, for example). This adds this method (hopefully in time for 1.74).