### PR TITLE
Bug-fix for one-sided cropping

### DIFF
--- a/include/boost/histogram/algorithm/reduce.hpp
+++ b/include/boost/histogram/algorithm/reduce.hpp
@@ -323,6 +323,8 @@ inline reduce_command slice_and_rebin(axis::index_type begin, axis::index_type e
   exception. Histograms with  non-reducible axes can still be reduced along the
   other axes that are reducible.
 
+  An overload allows one to pass reduce_command as positional arguments.
+
   @param hist original histogram.
   @param options iterable sequence of reduce commands: `shrink`, `slice`, `rebin`,
   `shrink_and_rebin`, or `slice_and_rebin`. The element type of the iterable should be
@@ -343,14 +345,16 @@ Histogram reduce(const Histogram& hist, const Iterable& options) {
         auto& o = opts[iaxis];
         o.is_ordered = axis::traits::ordered(a_in);
         if (o.merge > 0) { // option is set?
-          o.use_underflow_bin = !o.crop && AO::test(axis::option::underflow);
-          o.use_overflow_bin = !o.crop && AO::test(axis::option::overflow);
+          o.use_underflow_bin = AO::test(axis::option::underflow);
+          o.use_overflow_bin = AO::test(axis::option::overflow);
           return detail::static_if_c<axis::traits::is_reducible<A>::value>(
               [&o](const auto& a_in) {
                 if (o.range == reduce_command::range_t::none) {
+                  // no range restriction, pure rebin
                   o.begin.index = 0;
                   o.end.index = a_in.size();
                 } else {
+                  // range striction, convert values to indices as needed
                   if (o.range == reduce_command::range_t::values) {
                     const auto end_value = o.end.value;
                     o.begin.index = axis::traits::index(a_in, o.begin.value);
@@ -359,7 +363,14 @@ Histogram reduce(const Histogram& hist, const Iterable& options) {
                     if (axis::traits::value_as<double>(a_in, o.end.index) != end_value)
                       ++o.end.index;
                   }
-                  // limit [begin, end] to [0, size()]
+
+                  // crop flow bins if index range does not include them
+                  if (o.crop) {
+                    o.use_underflow_bin &= o.begin.index < 0;
+                    o.use_overflow_bin &= o.end.index > a_in.size();
+                  }
+
+                  // now limit [begin, end] to [0, size()]
                   if (o.begin.index < 0) o.begin.index = 0;
                   if (o.end.index > a_in.size()) o.end.index = a_in.size();
                 }
@@ -434,6 +445,8 @@ Histogram reduce(const Histogram& hist, const Iterable& options) {
   exception. It is safe to reduce histograms with some axis that are not reducible along
   the other axes. Trying to reducing a non-reducible axis triggers an invalid_argument
   exception.
+
+  An overload allows one to pass an iterable of reduce_command.
 
   @param hist original histogram.
   @param opt first reduce command; one of `shrink`, `slice`, `rebin`,

--- a/include/boost/histogram/algorithm/reduce.hpp
+++ b/include/boost/histogram/algorithm/reduce.hpp
@@ -115,6 +115,11 @@ inline reduce_command crop(unsigned iaxis, double lower, double upper) {
   range goes beyond the axis range, then the content of the underflow
   or overflow bin which overlaps with the range is kept.
 
+  If the counts in an existing underflow or overflow bin are discared by the crop, the
+  corresponding memory cells are not physically removed. Only their contents are set to
+  zero. This technical limitation may be lifted in the future, then crop may completely
+  remove the cropped memory cells.
+
   @param lower bin which contains lower is first to be kept.
   @param upper bin which contains upper is last to be kept, except if upper is equal to
   the lower edge.

--- a/include/boost/histogram/algorithm/reduce.hpp
+++ b/include/boost/histogram/algorithm/reduce.hpp
@@ -111,7 +111,9 @@ inline reduce_command crop(unsigned iaxis, double lower, double upper) {
   Command is applied to corresponding axis in order of reduce arguments.
 
   Works like `shrink` (see shrink documentation for details), but counts in removed bins
-  are discarded, whether underflow and overflow bins are present or not.
+  are discarded, whether underflow and overflow bins are present or not. If the cropped
+  range goes beyond the axis range, then the content of the underflow
+  or overflow bin which overlaps with the range is kept.
 
   @param lower bin which contains lower is first to be kept.
   @param upper bin which contains upper is last to be kept, except if upper is equal to

--- a/test/algorithm_reduce_test.cpp
+++ b/test/algorithm_reduce_test.cpp
@@ -237,39 +237,6 @@ void run_tests() {
     BOOST_TEST_EQ(hr, hr4);
   }
 
-  // one-sided cropping slice
-  {
-    auto h = make_s(Tag(), std::vector<int>(), ID(1, 4));
-    std::fill(h.begin(), h.end(), 1);
-    // underflow: 1
-    // index 0, x 1: 1
-    // index 1, x 2: 1
-    // index 2, x 3: 1
-    // overflow: 1
-    BOOST_TEST_EQ(sum(h), 5);
-    BOOST_TEST_EQ(h.size(), 5);
-
-    // keep underflow
-    auto hr1 = reduce(h, slice(-1, 2, slice_mode::crop));
-    BOOST_TEST_EQ(sum(hr1), 3);
-    BOOST_TEST_EQ(hr1.size(), 4); // flow bins are not physically removed, only zeroed
-
-    // remove underflow
-    auto hr2 = reduce(h, slice(0, 2, slice_mode::crop));
-    BOOST_TEST_EQ(sum(hr2), 2);
-    BOOST_TEST_EQ(hr2.size(), 4); // flow bins are not physically removed, only zeroed
-
-    // keep overflow
-    auto hr3 = reduce(h, slice(1, 4, slice_mode::crop));
-    BOOST_TEST_EQ(sum(hr3), 3);
-    BOOST_TEST_EQ(hr3.size(), 4); // flow bins are not physically removed, only zeroed
-
-    // remove overflow
-    auto hr4 = reduce(h, slice(1, 3, slice_mode::crop));
-    BOOST_TEST_EQ(sum(hr4), 2);
-    BOOST_TEST_EQ(hr4.size(), 4); // flow bins are not physically removed, only zeroed
-  }
-
   // one-sided crop
   {
     auto h = make_s(Tag(), std::vector<int>(), ID(1, 4));
@@ -284,21 +251,25 @@ void run_tests() {
 
     // keep underflow
     auto hr1 = reduce(h, crop(0, 3));
+    BOOST_TEST_EQ(hr1, reduce(h, slice(-1, 2, slice_mode::crop)));
     BOOST_TEST_EQ(sum(hr1), 3);
     BOOST_TEST_EQ(hr1.size(), 4); // flow bins are not physically removed, only zeroed
 
     // remove underflow
     auto hr2 = reduce(h, crop(1, 3));
+    BOOST_TEST_EQ(hr2, reduce(h, slice(0, 2, slice_mode::crop)));
     BOOST_TEST_EQ(sum(hr2), 2);
     BOOST_TEST_EQ(hr2.size(), 4); // flow bins are not physically removed, only zeroed
 
     // keep overflow
     auto hr3 = reduce(h, crop(2, 5));
+    BOOST_TEST_EQ(hr3, reduce(h, slice(1, 4, slice_mode::crop)));
     BOOST_TEST_EQ(sum(hr3), 3);
     BOOST_TEST_EQ(hr3.size(), 4); // flow bins are not physically removed, only zeroed
 
     // remove overflow
     auto hr4 = reduce(h, crop(2, 4));
+    BOOST_TEST_EQ(hr4, reduce(h, slice(1, 3, slice_mode::crop)));
     BOOST_TEST_EQ(sum(hr4), 2);
     BOOST_TEST_EQ(hr4.size(), 4); // flow bins are not physically removed, only zeroed
   }

--- a/test/algorithm_reduce_test.cpp
+++ b/test/algorithm_reduce_test.cpp
@@ -247,22 +247,27 @@ void run_tests() {
     // index 2, x 3: 1
     // overflow: 1
     BOOST_TEST_EQ(sum(h), 5);
+    BOOST_TEST_EQ(h.size(), 5);
 
     // keep underflow
     auto hr1 = reduce(h, slice(-1, 2, slice_mode::crop));
     BOOST_TEST_EQ(sum(hr1), 3);
+    BOOST_TEST_EQ(hr1.size(), 4); // flow bins are not physical removed, only zero
 
     // remove underflow
     auto hr2 = reduce(h, slice(0, 2, slice_mode::crop));
     BOOST_TEST_EQ(sum(hr2), 2);
+    BOOST_TEST_EQ(hr2.size(), 4); // flow bins are not physical removed, only zero
 
     // keep overflow
     auto hr3 = reduce(h, slice(1, 4, slice_mode::crop));
     BOOST_TEST_EQ(sum(hr3), 3);
+    BOOST_TEST_EQ(hr3.size(), 4); // flow bins are not physical removed, only zero
 
     // remove overflow
     auto hr4 = reduce(h, slice(1, 3, slice_mode::crop));
     BOOST_TEST_EQ(sum(hr4), 2);
+    BOOST_TEST_EQ(hr4.size(), 4); // flow bins are not physical removed, only zero
   }
 
   // mixed axis types

--- a/test/algorithm_reduce_test.cpp
+++ b/test/algorithm_reduce_test.cpp
@@ -252,22 +252,22 @@ void run_tests() {
     // keep underflow
     auto hr1 = reduce(h, slice(-1, 2, slice_mode::crop));
     BOOST_TEST_EQ(sum(hr1), 3);
-    BOOST_TEST_EQ(hr1.size(), 4); // flow bins are not physical removed, only zero
+    BOOST_TEST_EQ(hr1.size(), 4); // flow bins are not physically removed, only zeroed
 
     // remove underflow
     auto hr2 = reduce(h, slice(0, 2, slice_mode::crop));
     BOOST_TEST_EQ(sum(hr2), 2);
-    BOOST_TEST_EQ(hr2.size(), 4); // flow bins are not physical removed, only zero
+    BOOST_TEST_EQ(hr2.size(), 4); // flow bins are not physically removed, only zeroed
 
     // keep overflow
     auto hr3 = reduce(h, slice(1, 4, slice_mode::crop));
     BOOST_TEST_EQ(sum(hr3), 3);
-    BOOST_TEST_EQ(hr3.size(), 4); // flow bins are not physical removed, only zero
+    BOOST_TEST_EQ(hr3.size(), 4); // flow bins are not physically removed, only zeroed
 
     // remove overflow
     auto hr4 = reduce(h, slice(1, 3, slice_mode::crop));
     BOOST_TEST_EQ(sum(hr4), 2);
-    BOOST_TEST_EQ(hr4.size(), 4); // flow bins are not physical removed, only zero
+    BOOST_TEST_EQ(hr4.size(), 4); // flow bins are not physically removed, only zeroed
   }
 
   // one-sided crop
@@ -285,22 +285,22 @@ void run_tests() {
     // keep underflow
     auto hr1 = reduce(h, crop(0, 3));
     BOOST_TEST_EQ(sum(hr1), 3);
-    BOOST_TEST_EQ(hr1.size(), 4); // flow bins are not physical removed, only zero
+    BOOST_TEST_EQ(hr1.size(), 4); // flow bins are not physically removed, only zeroed
 
     // remove underflow
     auto hr2 = reduce(h, crop(1, 3));
     BOOST_TEST_EQ(sum(hr2), 2);
-    BOOST_TEST_EQ(hr2.size(), 4); // flow bins are not physical removed, only zero
+    BOOST_TEST_EQ(hr2.size(), 4); // flow bins are not physically removed, only zeroed
 
     // keep overflow
     auto hr3 = reduce(h, crop(2, 5));
     BOOST_TEST_EQ(sum(hr3), 3);
-    BOOST_TEST_EQ(hr3.size(), 4); // flow bins are not physical removed, only zero
+    BOOST_TEST_EQ(hr3.size(), 4); // flow bins are not physically removed, only zeroed
 
     // remove overflow
     auto hr4 = reduce(h, crop(2, 4));
     BOOST_TEST_EQ(sum(hr4), 2);
-    BOOST_TEST_EQ(hr4.size(), 4); // flow bins are not physical removed, only zero
+    BOOST_TEST_EQ(hr4.size(), 4); // flow bins are not physically removed, only zeroed
   }
 
   // mixed axis types

--- a/test/algorithm_reduce_test.cpp
+++ b/test/algorithm_reduce_test.cpp
@@ -237,7 +237,7 @@ void run_tests() {
     BOOST_TEST_EQ(hr, hr4);
   }
 
-  // one-sided crop
+  // one-sided cropping slice
   {
     auto h = make_s(Tag(), std::vector<int>(), ID(1, 4));
     std::fill(h.begin(), h.end(), 1);
@@ -266,6 +266,39 @@ void run_tests() {
 
     // remove overflow
     auto hr4 = reduce(h, slice(1, 3, slice_mode::crop));
+    BOOST_TEST_EQ(sum(hr4), 2);
+    BOOST_TEST_EQ(hr4.size(), 4); // flow bins are not physical removed, only zero
+  }
+
+  // one-sided crop
+  {
+    auto h = make_s(Tag(), std::vector<int>(), ID(1, 4));
+    std::fill(h.begin(), h.end(), 1);
+    // underflow: 1
+    // index 0, x 1: 1
+    // index 1, x 2: 1
+    // index 2, x 3: 1
+    // overflow: 1
+    BOOST_TEST_EQ(sum(h), 5);
+    BOOST_TEST_EQ(h.size(), 5);
+
+    // keep underflow
+    auto hr1 = reduce(h, crop(0, 3));
+    BOOST_TEST_EQ(sum(hr1), 3);
+    BOOST_TEST_EQ(hr1.size(), 4); // flow bins are not physical removed, only zero
+
+    // remove underflow
+    auto hr2 = reduce(h, crop(1, 3));
+    BOOST_TEST_EQ(sum(hr2), 2);
+    BOOST_TEST_EQ(hr2.size(), 4); // flow bins are not physical removed, only zero
+
+    // keep overflow
+    auto hr3 = reduce(h, crop(2, 5));
+    BOOST_TEST_EQ(sum(hr3), 3);
+    BOOST_TEST_EQ(hr3.size(), 4); // flow bins are not physical removed, only zero
+
+    // remove overflow
+    auto hr4 = reduce(h, crop(2, 4));
     BOOST_TEST_EQ(sum(hr4), 2);
     BOOST_TEST_EQ(hr4.size(), 4); // flow bins are not physical removed, only zero
   }


### PR DESCRIPTION
Fixes a bug when `reduce` is used with one-sided `crop`, where "one-sided" means that the cropping is supposed to remove only the upper part of an axis including the overflow bin, but keep the lower end including the underflow bin or vice versa.

The current (wrong) behavior of `crop` is to always remove the *flow contents on both ends.