### PR TITLE
Fix variance calculation in accumulators::mean::operator+=

### DIFF
--- a/include/boost/histogram/algorithm/sum.hpp
+++ b/include/boost/histogram/algorithm/sum.hpp
@@ -49,6 +49,7 @@ namespace algorithm {
 template <class A, class S>
 auto sum(const histogram<A, S>& hist, const coverage cov = coverage::all) {
   using T = typename histogram<A, S>::value_type;
+  // T is arithmetic, compute sum accurately with high dynamic range
   using sum_type = mp11::mp_if<std::is_arithmetic<T>, accumulators::sum<double>, T>;
   sum_type sum;
   if (cov == coverage::all)


### PR DESCRIPTION
The variance calculation of accumulators::mean::operator+= was broken. This was not caught by the corresponding test, since the test only checked the case when the two summed means were identical, where the faulty implementation happened to give the right answer.

The problem is fixed and a new test was added to check that the sum of two different mean accumulator states gives the same outcome as filling one accumulator with the data of both.