### PR TITLE
Support floating point numbers in thread_safe accumulator

### DIFF
--- a/include/boost/histogram/accumulators/ostream.hpp
+++ b/include/boost/histogram/accumulators/ostream.hpp
@@ -95,7 +95,7 @@ std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>&
 template <class CharT, class Traits, class T>
 std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>& os,
                                               const thread_safe<T>& x) {
-  os << x.load();
+  os << static_cast<T>(x);
   return os;
 }
 } // namespace accumulators

--- a/include/boost/histogram/accumulators/thread_safe.hpp
+++ b/include/boost/histogram/accumulators/thread_safe.hpp
@@ -132,36 +132,28 @@ private:
   }
 
   // workaround for floating point numbers in C++14, obsolete in C++20
-  template <class U = value_type>
-  void increment_impl(detail::priority<0>) {
-    operator+=(static_cast<value_type>(1));
-  }
+  void increment_impl(detail::priority<0>) { operator+=(static_cast<value_type>(1)); }
 
   // workaround for floating point numbers in C++14, obsolete in C++20
-  template <class U = value_type>
   void add_impl(detail::priority<0>, value_type arg) {
     value_type expected = value_.load();
     // if another tread changed expected value, compare_exchange returns false
-    // and updates expected; we then loop and try to update again
+    // and updates expected; we then loop and try to update again;
     // see https://en.cppreference.com/w/cpp/atomic/atomic/compare_exchange
     while (!value_.compare_exchange_weak(expected, expected + arg))
       ;
   }
 
+  friend bool operator==(const_reference x, const thread_safe& rhs) noexcept {
+    return rhs.operator==(x);
+  }
+
+  friend bool operator!=(const_reference x, const thread_safe& rhs) noexcept {
+    return rhs.operator!=(x);
+  }
+
   std::atomic<T> value_;
 };
-
-template <class T, class U>
-std::enable_if_t<std::is_arithmetic<T>::value, bool> operator==(
-    const T& t, const thread_safe<U>& rhs) noexcept {
-  return rhs.operator==(t);
-}
-
-template <class T, class U>
-std::enable_if_t<std::is_arithmetic<T>::value, bool> operator!=(
-    const T& t, const thread_safe<U>& rhs) noexcept {
-  return rhs.operator!=(t);
-}
 
 } // namespace accumulators
 } // namespace histogram

--- a/include/boost/histogram/accumulators/thread_safe.hpp
+++ b/include/boost/histogram/accumulators/thread_safe.hpp
@@ -154,13 +154,13 @@ private:
 template <class T, class U>
 std::enable_if_t<std::is_arithmetic<T>::value, bool> operator==(
     const T& t, const thread_safe<U>& rhs) noexcept {
-  return rhs == t;
+  return rhs.operator==(t);
 }
 
 template <class T, class U>
 std::enable_if_t<std::is_arithmetic<T>::value, bool> operator!=(
     const T& t, const thread_safe<U>& rhs) noexcept {
-  return rhs != t;
+  return rhs.operator!=(t);
 }
 
 } // namespace accumulators

--- a/include/boost/histogram/accumulators/thread_safe.hpp
+++ b/include/boost/histogram/accumulators/thread_safe.hpp
@@ -56,17 +56,23 @@ public:
     return *this;
   }
 
+  /// Increment value by one.
   thread_safe& operator++() {
     increment_impl(detail::priority<1>{});
     return *this;
   }
 
+  /// Increment value by argument.
   thread_safe& operator+=(value_type arg) {
     add_impl(detail::priority<1>{}, arg);
     return *this;
   }
 
-  operator value_type() const noexcept { return value_.load(); }
+  /// Return value.
+  const_reference value() const noexcept { return value_.load(); }
+
+  // conversion to value_type should be explicit
+  explicit operator value_type() const noexcept { return value_.load(); }
 
   template <class Archive>
   void serialize(Archive& ar, unsigned /* version */) {

--- a/include/boost/histogram/accumulators/thread_safe.hpp
+++ b/include/boost/histogram/accumulators/thread_safe.hpp
@@ -17,7 +17,7 @@ namespace boost {
 namespace histogram {
 namespace accumulators {
 
-/** Thread-safe adaptor for builtin integral and floating point numbers.
+/** Thread-safe adaptor for integral and floating point numbers.
 
   This adaptor uses std::atomic to make concurrent increments and additions safe for the
   stored value.
@@ -27,7 +27,12 @@ namespace accumulators {
   instruction. On exotic platforms the size of the adapted number may be larger and/or the
   type may have different alignment, which means it cannot be tightly packed into arrays.
 
-  @tparam T type to adapt, must be supported by std::atomic.
+  This implementation uses a workaround to support atomic operations on floating point
+  numbers in C++14. Compiling with C++20 may increase performance for
+  operations on floating point numbers. The implementation automatically uses the best
+  implementation that is available.
+
+  @tparam T type to adapt; must be arithmetic (integer or floating point).
  */
 template <class T>
 class thread_safe : public std::atomic<T> {
@@ -83,13 +88,13 @@ private:
     return super_t::fetch_add(arg);
   }
 
-  // support for floating point numbers in C++14
+  // workaround for floating point numbers in C++14, obsolete in C++20
   template <class U = value_type>
   void increment_impl(detail::priority<0>) {
     operator+=(static_cast<value_type>(1));
   }
 
-  // support for floating point numbers in C++14
+  // workaround for floating point numbers in C++14, obsolete in C++20
   template <class U = value_type>
   void add_impl(detail::priority<0>, value_type arg) {
     value_type expected = super_t::load();

--- a/include/boost/histogram/accumulators/thread_safe.hpp
+++ b/include/boost/histogram/accumulators/thread_safe.hpp
@@ -40,7 +40,8 @@ public:
   static_assert(std::is_arithmetic<T>(), "");
 
   using value_type = T;
-  using atomic_value_type = std::atomic<value_type>;
+  using const_reference = const T&;
+  using atomic_value_type = std::atomic<T>;
 
   thread_safe() noexcept : value_{static_cast<value_type>(0)} {}
   // non-atomic copy and assign is allowed, because storage is locked in this case
@@ -69,7 +70,7 @@ public:
   }
 
   /// Return value.
-  const_reference value() const noexcept { return value_.load(); }
+  value_type value() const noexcept { return value_.load(); }
 
   // conversion to value_type should be explicit
   explicit operator value_type() const noexcept { return value_.load(); }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,7 +44,6 @@ set(BOOST_TEST_LINK_LIBRARIES Boost::histogram Boost::core)
 boost_test(TYPE run SOURCES accumulators_count_test.cpp)
 boost_test(TYPE run SOURCES accumulators_mean_test.cpp)
 boost_test(TYPE run SOURCES accumulators_sum_test.cpp)
-boost_test(TYPE run SOURCES accumulators_thread_safe_test.cpp)
 boost_test(TYPE run SOURCES accumulators_weighted_mean_test.cpp)
 boost_test(TYPE run SOURCES accumulators_weighted_sum_test.cpp)
 boost_test(TYPE run SOURCES algorithm_project_test.cpp)
@@ -97,6 +96,8 @@ if (Threads_FOUND)
   boost_test(TYPE run SOURCES histogram_threaded_test.cpp
     LINK_LIBRARIES Threads::Threads)
   boost_test(TYPE run SOURCES storage_adaptor_threaded_test.cpp
+    LINK_LIBRARIES Threads::Threads)
+  boost_test(TYPE run SOURCES accumulators_thread_safe_test.cpp
     LINK_LIBRARIES Threads::Threads)
 
 endif()

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -45,7 +45,6 @@ alias cxx14 :
       # make sure sum accumulator works even with -ffast-math and optimizations
       <toolset>gcc:<cxxflags>"-O3 -ffast-math"
       <toolset>clang:<cxxflags>"-O3 -ffast-math" ]
-    [ run accumulators_thread_safe_test.cpp ]
     [ run accumulators_weighted_mean_test.cpp ]
     [ run accumulators_weighted_sum_test.cpp ]
     [ run algorithm_project_test.cpp ]
@@ -123,6 +122,7 @@ alias failure :
 alias threading :
     [ run histogram_threaded_test.cpp ]
     [ run storage_adaptor_threaded_test.cpp ]
+    [ run accumulators_thread_safe_test.cpp ]
     :
     <threading>multi
     ;

--- a/test/accumulators_thread_safe_test.cpp
+++ b/test/accumulators_thread_safe_test.cpp
@@ -8,23 +8,75 @@
 #include <boost/histogram/accumulators/ostream.hpp>
 #include <boost/histogram/accumulators/thread_safe.hpp>
 #include <sstream>
+#include <thread>
 #include "throw_exception.hpp"
 #include "utility_str.hpp"
 
 using namespace boost::histogram;
 using namespace std::literals;
 
-int main() {
-  using ts_t = accumulators::thread_safe<int>;
+template <class F>
+void parallel(F f) {
+  auto g = [&]() {
+    for (int i = 0; i < 1000; ++i) f();
+  };
 
-  ts_t i;
-  ++i;
-  i += 1000;
+  std::thread a(g), b(g), c(g), d(g);
+  a.join();
+  b.join();
+  c.join();
+  d.join();
+}
 
-  BOOST_TEST_EQ(i, 1001);
-  BOOST_TEST_EQ(str(i), "1001"s);
+template <class T>
+void test_on() {
+  using ts_t = accumulators::thread_safe<T>;
 
+  // default ctor
+  {
+    ts_t i;
+    BOOST_TEST_EQ(i, 0);
+  }
+
+  // ctor from value
+  {
+    ts_t i{1001};
+    BOOST_TEST_EQ(i, 1001);
+    BOOST_TEST_EQ(str(i), "1001"s);
+  }
+
+  // add null
   BOOST_TEST_EQ(ts_t{} += ts_t{}, ts_t{});
+
+  // add non-null
+  BOOST_TEST_EQ((ts_t{} += ts_t{2}), (ts_t{2}));
+
+  // operator++
+  {
+    ts_t t;
+    parallel([&]() { ++t; });
+    BOOST_TEST_EQ(t, 4000);
+  }
+
+  // operator+= with value
+  {
+    ts_t t;
+    parallel([&]() { t += 2; });
+    BOOST_TEST_EQ(t, 8000);
+  }
+
+  // operator+= with another thread_safe
+  {
+    ts_t t, u;
+    u = 2;
+    parallel([&]() { t += u; });
+    BOOST_TEST_EQ(t, 8000);
+  }
+}
+
+int main() {
+  test_on<int>();
+  test_on<float>();
 
   return boost::report_errors();
 }

--- a/test/accumulators_thread_safe_test.cpp
+++ b/test/accumulators_thread_safe_test.cpp
@@ -15,10 +15,12 @@
 using namespace boost::histogram;
 using namespace std::literals;
 
+constexpr int N = 10000;
+
 template <class F>
 void parallel(F f) {
   auto g = [&]() {
-    for (int i = 0; i < 1000; ++i) f();
+    for (int i = 0; i < N; ++i) f();
   };
 
   std::thread a(g), b(g), c(g), d(g);
@@ -55,14 +57,14 @@ void test_on() {
   {
     ts_t t;
     parallel([&]() { ++t; });
-    BOOST_TEST_EQ(t, 4000);
+    BOOST_TEST_EQ(t, 4 * N);
   }
 
   // operator+= with value
   {
     ts_t t;
     parallel([&]() { t += 2; });
-    BOOST_TEST_EQ(t, 8000);
+    BOOST_TEST_EQ(t, 8 * N);
   }
 
   // operator+= with another thread_safe
@@ -70,7 +72,7 @@ void test_on() {
     ts_t t, u;
     u = 2;
     parallel([&]() { t += u; });
-    BOOST_TEST_EQ(t, 8000);
+    BOOST_TEST_EQ(t, 8 * N);
   }
 }
 

--- a/test/accumulators_thread_safe_test.cpp
+++ b/test/accumulators_thread_safe_test.cpp
@@ -43,7 +43,7 @@ void test_on() {
   // ctor from value
   {
     ts_t i{1001};
-    BOOST_TEST_EQ(i, 1001);
+    BOOST_TEST_EQ(i, static_cast<T>(1001));
     BOOST_TEST_EQ(str(i), "1001"s);
   }
 
@@ -57,14 +57,14 @@ void test_on() {
   {
     ts_t t;
     parallel([&]() { ++t; });
-    BOOST_TEST_EQ(t, 4 * N);
+    BOOST_TEST_EQ(t, static_cast<T>(4 * N));
   }
 
   // operator+= with value
   {
     ts_t t;
     parallel([&]() { t += 2; });
-    BOOST_TEST_EQ(t, 8 * N);
+    BOOST_TEST_EQ(t, static_cast<T>(8 * N));
   }
 
   // operator+= with another thread_safe
@@ -72,13 +72,22 @@ void test_on() {
     ts_t t, u;
     u = 2;
     parallel([&]() { t += u; });
-    BOOST_TEST_EQ(t, 8 * N);
+    BOOST_TEST_EQ(t, static_cast<T>(8 * N));
   }
 }
 
 int main() {
   test_on<int>();
   test_on<float>();
+
+  // copy and assignment from other thread_safe
+  {
+    accumulators::thread_safe<char> r{1};
+    accumulators::thread_safe<int> a{r}, b;
+    b = r;
+    BOOST_TEST_EQ(a, 1);
+    BOOST_TEST_EQ(b, 1);
+  }
 
   return boost::report_errors();
 }

--- a/test/accumulators_thread_safe_test.cpp
+++ b/test/accumulators_thread_safe_test.cpp
@@ -35,7 +35,7 @@ void test_on() {
   // default ctor
   {
     ts_t i;
-    BOOST_TEST_EQ(i, 0);
+    BOOST_TEST_EQ(i, static_cast<T>(0));
   }
 
   // ctor from value


### PR DESCRIPTION
This adds a workaround for floating point numbers that I learned from discussion with @emanca.

We further stop inheriting from `std::atomic` for better encapsulation.