### PR TITLE
Generalize indexed

### DIFF
--- a/doc/doxygen_postprocessing.py
+++ b/doc/doxygen_postprocessing.py
@@ -25,7 +25,7 @@ def is_detail(x):
     if x.text is not None:
         if "detail" in x.text:
             return True
-        m = re.match("(?:typename)? *([A-Za-z0-9_\:]+)", x.text)
+        m = re.match(r"(?:typename)? *([A-Za-z0-9_\:]+)", x.text)
         if m is not None:
             s = m.group(1)
             if s.startswith("detail") or s.endswith("_impl"):
@@ -121,6 +121,17 @@ for item in select(is_deprecated, "typedef"):
         parent.get("name"),
     )
     parent.remove(item)
+
+# replace any typedef with "unspecified"
+for item in select(is_detail, "typedef"):
+    log("replacing typedef", item.get("name"), 'with "unspecified"')
+    name = item.get("name")
+    item.clear()
+    item.tag = "typedef"
+    item.set("name", name)
+    type = ET.Element("type")
+    type.append(unspecified)
+    item.append(type)
 
 # hide private member functions
 for item in select(

--- a/include/boost/histogram/detail/debug.hpp
+++ b/include/boost/histogram/detail/debug.hpp
@@ -1,0 +1,20 @@
+// Copyright 2019 Hans Dembinski
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_HISTOGRAM_DETAIL_DEBUG_HPP
+#define BOOST_HISTOGRAM_DETAIL_DEBUG_HPP
+
+#warning "debug.hpp included"
+
+#include <boost/histogram/detail/type_name.hpp>
+#include <iostream>
+
+#define DEBUG(x)                                                                      \
+  std::cout << __FILE__ << ":" << __LINE__ << " ["                                    \
+            << boost::histogram::detail::type_name<decltype(x)>() << "] " #x "=" << x \
+            << std::endl;
+
+#endif

--- a/include/boost/histogram/indexed.hpp
+++ b/include/boost/histogram/indexed.hpp
@@ -11,7 +11,6 @@
 #include <boost/config.hpp> // BOOST_ATTRIBUTE_NODISCARD
 #include <boost/histogram/axis/traits.hpp>
 #include <boost/histogram/detail/axes.hpp>
-#include <boost/histogram/detail/debug.hpp>
 #include <boost/histogram/detail/detect.hpp>
 #include <boost/histogram/detail/iterator_adaptor.hpp>
 #include <boost/histogram/detail/operators.hpp>
@@ -29,7 +28,7 @@ using std::get;
 
 template <std::size_t I, class T>
 auto get(T&& t) -> decltype(t[0]) {
-  return t[0];
+  return t[I];
 }
 } // namespace detail
 
@@ -316,9 +315,7 @@ public:
   };
 
   indexed_range(histogram_type& hist, coverage cov)
-      : indexed_range(hist, make_range(hist, cov)) {
-    DEBUG("foo");
-  }
+      : indexed_range(hist, make_range(hist, cov)) {}
 
   template <class Iterable, class = detail::requires_iterable<Iterable>>
   indexed_range(histogram_type& hist, Iterable&& range)
@@ -344,12 +341,7 @@ public:
       begin_.iter_ += ca->begin_skip;
 
       stride *= stop - start;
-      DEBUG(detail::get<0>(*r_begin));
-      DEBUG(ca->begin)
-      DEBUG(ca->begin_skip)
-      DEBUG(ca->end)
-      DEBUG(ca->end_skip)
-      DEBUG(stride)
+
       ++ca;
       ++r_begin;
     });
@@ -401,14 +393,12 @@ private:
  */
 template <class Histogram>
 auto indexed(Histogram&& hist, coverage cov = coverage::inner) {
-  DEBUG("coverage");
   return indexed_range<std::remove_reference_t<Histogram>>{std::forward<Histogram>(hist),
                                                            cov};
 }
 
 template <class Histogram, class Iterable, class = detail::requires_iterable<Iterable>>
 auto indexed(Histogram&& hist, Iterable&& range) {
-  DEBUG("iterable");
   return indexed_range<std::remove_reference_t<Histogram>>{std::forward<Histogram>(hist),
                                                            std::forward<Iterable>(range)};
 }

--- a/test/check_build_system.py
+++ b/test/check_build_system.py
@@ -25,7 +25,7 @@ for dir in (pj(project_path, "test"), pj(project_path, "examples")):
         filename = os.path.join(dir, build_file)
         if not os.path.exists(filename):
             continue
-        run = set(re.findall("([a-zA-Z0-9_]+\.cpp)", open(filename).read()))
+        run = set(re.findall(r"([a-zA-Z0-9_]+\.cpp)", open(filename).read()))
 
         diff = cpp - run
         diff.discard("check_cmake_version.cpp")  # ignore

--- a/test/check_odr_test.py
+++ b/test/check_odr_test.py
@@ -31,6 +31,8 @@ for root, dirs, files in os.walk(include_path):
     for fn in files:
         fn = os.path.join(root, fn)
         fn = fn[len(root_include_path) :]
+        if fn == "boost/histogram/detail/debug.hpp":  # is never included
+            continue
         all_headers.add(fn)
 
 

--- a/test/check_odr_test.py
+++ b/test/check_odr_test.py
@@ -31,7 +31,7 @@ for root, dirs, files in os.walk(include_path):
     for fn in files:
         fn = os.path.join(root, fn)
         fn = fn[len(root_include_path) :]
-        if fn == "boost/histogram/detail/debug.hpp":  # is never included
+        if fn.endswith("debug.hpp"):  # is never included
             continue
         all_headers.add(fn)
 

--- a/test/indexed_test.cpp
+++ b/test/indexed_test.cpp
@@ -156,15 +156,52 @@ void run_stdlib_tests(mp_list<Tag, Coverage>) {
   }
 }
 
+template <class Tag>
+void run_indexed_with_range_tests(Tag) {
+  {
+    auto ax = axis::integer<>(0, 4);
+    auto ay = axis::integer<>(0, 3);
+
+    auto h = make(Tag(), ax, ay);
+    for (auto&& x : indexed(h, coverage::all)) x = x.index(0) + x.index(1);
+    BOOST_TEST_EQ(h.at(0, 0), 0);
+    BOOST_TEST_EQ(h.at(0, 1), 1);
+    BOOST_TEST_EQ(h.at(0, 2), 2);
+    BOOST_TEST_EQ(h.at(1, 0), 1);
+    BOOST_TEST_EQ(h.at(1, 1), 2);
+    BOOST_TEST_EQ(h.at(1, 2), 3);
+    BOOST_TEST_EQ(h.at(2, 0), 2);
+    BOOST_TEST_EQ(h.at(2, 1), 3);
+    BOOST_TEST_EQ(h.at(2, 2), 4);
+    BOOST_TEST_EQ(h.at(3, 0), 3);
+    BOOST_TEST_EQ(h.at(3, 1), 4);
+    BOOST_TEST_EQ(h.at(3, 2), 5);
+
+    /* x->
+    y  0 1 2 3
+    |  1 2 3 4
+    v  2 3 4 5
+    */
+
+    int range[2][2] = {{1, 3}, {0, 2}};
+    auto ir = indexed(h, range);
+    auto sum = std::accumulate(ir.begin(), ir.end(), 0);
+    BOOST_TEST_EQ(sum, 1 + 2 + 2 + 3);
+  }
+}
+
 int main() {
-  mp_for_each<mp_product<mp_list, mp_list<static_tag, dynamic_tag>,
-                         mp_list<std::integral_constant<coverage, coverage::inner>,
-                                 std::integral_constant<coverage, coverage::all>>>>(
-      [](auto&& x) {
-        run_1d_tests(x);
-        run_3d_tests(x);
-        run_density_tests(x);
-        run_stdlib_tests(x);
-      });
+  // mp_for_each<mp_product<mp_list, mp_list<static_tag, dynamic_tag>,
+  //                        mp_list<std::integral_constant<coverage, coverage::inner>,
+  //                                std::integral_constant<coverage, coverage::all>>>>(
+  //     [](auto&& x) {
+  //       run_1d_tests(x);
+  //       run_3d_tests(x);
+  //       run_density_tests(x);
+  //       run_stdlib_tests(x);
+  //     });
+
+  run_indexed_with_range_tests(static_tag{});
+  // run_indexed_with_range_tests(dynamic_tag{});
   return boost::report_errors();
 }

--- a/test/indexed_test.cpp
+++ b/test/indexed_test.cpp
@@ -191,17 +191,17 @@ void run_indexed_with_range_tests(Tag) {
 }
 
 int main() {
-  // mp_for_each<mp_product<mp_list, mp_list<static_tag, dynamic_tag>,
-  //                        mp_list<std::integral_constant<coverage, coverage::inner>,
-  //                                std::integral_constant<coverage, coverage::all>>>>(
-  //     [](auto&& x) {
-  //       run_1d_tests(x);
-  //       run_3d_tests(x);
-  //       run_density_tests(x);
-  //       run_stdlib_tests(x);
-  //     });
+  mp_for_each<mp_product<mp_list, mp_list<static_tag, dynamic_tag>,
+                         mp_list<std::integral_constant<coverage, coverage::inner>,
+                                 std::integral_constant<coverage, coverage::all>>>>(
+      [](auto&& x) {
+        run_1d_tests(x);
+        run_3d_tests(x);
+        run_density_tests(x);
+        run_stdlib_tests(x);
+      });
 
   run_indexed_with_range_tests(static_tag{});
-  // run_indexed_with_range_tests(dynamic_tag{});
+  run_indexed_with_range_tests(dynamic_tag{});
   return boost::report_errors();
 }

--- a/test/indexed_test.cpp
+++ b/test/indexed_test.cpp
@@ -185,7 +185,7 @@ void run_indexed_with_range_tests(Tag) {
 
     int range[2][2] = {{1, 3}, {0, 2}};
     auto ir = indexed(h, range);
-    auto sum = std::accumulate(ir.begin(), ir.end(), 0);
+    auto sum = std::accumulate(ir.begin(), ir.end(), 0.0);
     BOOST_TEST_EQ(sum, 1 + 2 + 2 + 3);
   }
 }


### PR DESCRIPTION
Closes #277 

```c++
auto ax = axis::integer<>(0, 4);
auto ay = axis::integer<>(0, 3);

auto h = make(Tag(), ax, ay);
for (auto&& x : indexed(h, coverage::all)) x = x.index(0) + x.index(1);

int range[2][2] = {{1, 3}, {0, 2}};
auto ir = indexed(h, range);
auto sum = std::accumulate(ir.begin(), ir.end(), 0); // returns 1 + 2 + 2 + 3
```