### PR TITLE
Update lcov coverage

### DIFF
--- a/.github/workflows/cov.yml
+++ b/.github/workflows/cov.yml
@@ -10,54 +10,129 @@ on:
       - 'examples/**'
       - 'tools/**'
       - '*.md'
+  push:
+    branches:
+      - master
+      - develop
+      - feature/**
+      - test*
 
 env:
+  UBSAN_OPTIONS: print_stacktrace=1
   B2_OPTS: -q -j2 warnings-as-errors=on
 
 jobs:
-  cov:
-    runs-on: macos-10.15
+  posix:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - toolset: gcc-5
+            gcov: gcov-5
+            cxxstd: "03,11,14,1z"
+            os: ubuntu-16.04
+          - toolset: gcc-6
+            gcov: gcov-6
+            cxxstd: "03,11,14,1z"
+            os: ubuntu-16.04
+            install: g++-6
+          - toolset: gcc-7
+            gcov: gcov-7
+            cxxstd: "03,11,14,17"
+            os: ubuntu-18.04
+          - toolset: gcc-8
+            gcov: gcov-8
+            cxxstd: "03,11,14,17,2a"
+            os: ubuntu-18.04
+            install: g++-8
+          - toolset: gcc-9
+            gcov: gcov-9
+            cxxstd: "03,11,14,17,2a"
+            os: ubuntu-18.04
+          - toolset: gcc-10
+            gcov: gcov-10
+            cxxstd: "03,11,14,17,2a"
+            os: ubuntu-18.04
+          - toolset: clang
+            compiler: clang++-10
+            gcov: 'gcov_for_clang.sh'
+            llvm_cov_path: '/usr/bin/llvm-cov-10'
+            cxxstd: "03,11,14,17,2a"
+            os: ubuntu-20.04
+          - toolset: clang
+            compiler: clang++-11
+            gcov: 'gcov_for_clang.sh'
+            llvm_cov_path: '/usr/bin/llvm-cov-11'
+            cxxstd: "03,11,14,17,2a"
+            os: ubuntu-20.04
+          - toolset: gcc-8
+            cxxstd: "03,11,14,17,2a"
+            gcov: gcov-8
+            os: macos-10.15
+
+    runs-on: ${{matrix.os}}
+
     steps:
-    - uses: actions/checkout@v2
-    - name: Fetch Boost superproject
-      run: |
-        cd ..
-        git clone -b $GITHUB_BASE_REF --depth 5 https://github.com/boostorg/boost.git
-        cd boost
-        mv -f $GITHUB_WORKSPACE/* libs/histogram
-        git submodule update --init --depth 5 tools/build tools/boostdep
-        python tools/boostdep/depinst/depinst.py --git_args "--depth 5 --jobs 3" histogram
-        mv -f * $GITHUB_WORKSPACE
+      - uses: actions/checkout@v2
 
-        # # use hdembinski/serialization due to frequent errors in boostorg/serialization
-        # pushd libs/serialization
-        # git remote add patch https://github.com/HDembinski/serialization.git
-        # git fetch patch
-        # git checkout patch/boost_histogram
-        # popd
+      - name: Install packages
+        if: matrix.install
+        run: sudo apt install ${{matrix.install}}
 
-    - name: Prepare b2
-      run: |
-        ./bootstrap.sh
-        ./b2 headers
+      - name: Setup Boost
+        run: |
+          echo GITHUB_REPOSITORY: $GITHUB_REPOSITORY
+          LIBRARY=${GITHUB_REPOSITORY#*/}
+          echo LIBRARY: $LIBRARY
+          echo "LIBRARY=$LIBRARY" >> $GITHUB_ENV
+          echo GITHUB_BASE_REF: $GITHUB_BASE_REF
+          echo GITHUB_REF: $GITHUB_REF
+          REF=${GITHUB_BASE_REF:-$GITHUB_REF}
+          REF=${REF#refs/heads/}
+          echo REF: $REF
+          BOOST_BRANCH=develop && [ "$REF" == "master" ] && BOOST_BRANCH=master || true
+          echo BOOST_BRANCH: $BOOST_BRANCH
+          cd ..
+          git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
+          cd boost-root
+          cp -r $GITHUB_WORKSPACE/* libs/$LIBRARY
+          git submodule update --init tools/boostdep
+          python tools/boostdep/depinst/depinst.py --git_args "--jobs 3" $LIBRARY
+          ./bootstrap.sh
+          ./b2 -d0 headers
 
-        # simulate bundled boost by moving the headers instead of symlinking
-        rm -rf boost/histogram*
-        mv -f libs/histogram/include/boost/* boost
+      - name: Create user-config.jam
+        if: matrix.compiler
+        run: |
+          echo "using ${{matrix.toolset}} : : ${{matrix.compiler}} ;" > ~/user-config.jam
 
-    - name: Test cxxstd=latest coverage=on
-      run: |
-        cd libs/histogram
+# - name: Run tests
+#   run: |
+#     cd ../boost-root
+#     ./b2 -j3 libs/$LIBRARY/test toolset=${{matrix.toolset}} cxxstd=${{matrix.cxxstd}} variant=debug,release
 
-        # don't compile examples in coverage build, coverage must come from tests alone
-        ../../b2 $B2_OPTS toolset=gcc-8 cxxstd=latest coverage=on test//all
 
-    - name: Process coverage data
-      run: |
-        cd libs/histogram
-        GCOV=gcov-8 tools/cov.sh
+# cd libs/histogram
+# ## don't compile examples in coverage build, coverage must come from tests alone
+# ../../b2 $B2_OPTS toolset=gcc-8 cxxstd=latest coverage=on test//all
 
-    - uses: coverallsapp/github-action@v1.1.2
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: libs/histogram/coverage.info
+      - name: Test cxxstd=latest coverage=on
+        run: |
+          cd ../boost-root
+          # "merging" histogram's example and core's example:
+          ./b2 -j3 libs/$LIBRARY/test//all toolset=${{matrix.toolset}} cxxstd=latest coverage=on
+  
+      - name: Process coverage data
+        env:
+          GCOV: ${{ matrix.gcov }}
+          LLVM_COV_PATH: ${{ matrix.llvm_cov_path }}
+        run: |
+          # cd libs/histogram
+          cd ../boost-root/libs/histogram
+          # GCOV=gcov-8 tools/cov.sh
+          tools/cov.sh
+
+      - uses: coverallsapp/github-action@v1.1.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ../boost-root/libs/histogram/coverage.info

--- a/tools/cov.sh
+++ b/tools/cov.sh
@@ -1,12 +1,14 @@
-#!/bin/sh
+#!/bin/bash
+
 # must be executed in project root folder
 
 # Copyright Hans Dembinski 2018-2019
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 
+set -ex
+
 if [ -z $GCOV ]; then
-  # gcov-10, gcov-9, gcov-7, gcov-6 do not work
   for i in 8 5; do
     if test $(which gcov-$i); then
       GCOV=gcov-$i
@@ -15,7 +17,7 @@ if [ -z $GCOV ]; then
   done
 fi
 
-LCOV_VERSION="1.14"
+LCOV_VERSION="1.15"
 LCOV_DIR="tools/lcov-${LCOV_VERSION}"
 
 if [ ! -e $LCOV_DIR ]; then
@@ -24,23 +26,38 @@ if [ ! -e $LCOV_DIR ]; then
   cd ..
 fi
 
+# For clang
+if [ -n "$LLVM_COV_PATH" ]; then
+  sudo ln -s $LLVM_COV_PATH /usr/bin/llvm-cov || true
+else
+  sudo ln -s /usr/bin/llvm-cov-11 /usr/bin/llvm-cov || true
+fi
+
+mkdir -p ~/.local/bin
+echo -e '#!/bin/bash\nexec llvm-cov gcov "$@"' > ~/.local/bin/gcov_for_clang.sh
+chmod 755 ~/.local/bin/gcov_for_clang.sh
+
 # --rc lcov_branch_coverage=1 doesn't work on travis
 # LCOV="${LCOV_DIR}/bin/lcov --gcov-tool=${GCOV} --rc lcov_branch_coverage=1"
 LCOV="${LCOV_DIR}/bin/lcov --gcov-tool=${GCOV}"
 
-# collect raw data
-$LCOV --base-directory `pwd` \
+echo "collect raw data"
+$LCOV --base-directory `pwd`/../../ \
   --directory `pwd`/../../bin.v2/libs/histogram/test \
   --capture --output-file coverage.info
+echo "done with first run of lcov"
 
-# remove uninteresting entries
+echo "remove uninteresting entries"
 $LCOV --extract coverage.info "*/boost/histogram/*" --output-file coverage.info
+echo "done with extraction"
 
 if [ $1 ]; then
+  echo "Uploading to cpp-coveralls"
   # upload if on CI or when token is passed as argument
   which cpp-coveralls || echo "Error: you need to install cpp-coveralls"
   cpp-coveralls -l coverage.info -r ../.. -n -t $1
 elif [ ! $CI ]; then
+  echo "Generating html report"
   # otherwise generate html report
   $LCOV_DIR/bin/genhtml coverage.info --demangle-cpp -o coverage-report
 fi

--- a/tools/cov_offline.sh
+++ b/tools/cov_offline.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+#################
+#
+# Instructions
+#
+# Run this script in a docker container (such as ubuntu:20.04), a local machine, or a cloud instance.
+# It will build the library, and run lcov.
+# The repository will initially be placed at /opt/github/$LIBRARY
+# and the final coverage.info file /opt/github/boost-root/libs/$LIBRARY/coverage.info
+#
+# If you would like to upload the results to coveralls.io, set an env variable
+# export COVERALLS_REPO_TOKEN=__
+
+set -xe
+LIBRARY_URL=https://github.com/boostorg/histogram
+LIBRARY=$(basename $LIBRARY_URL)
+GITHUB_WORKSPACE=/opt/github/$LIBRARY
+TOOLSET=gcc-8
+GCOV=gcov-8
+CXXSTD="03,11,14,17,2a"
+BASE_PACKAGES="git python3 build-essential g++ curl wget mlocate vim"
+PACKAGES="g++-8 $BASE_PACKAGES"
+# LCOV_COV_PATH=
+UBSAN_OPTIONS="print_stacktrace=1"
+B2_OPTS="-q -j2 warnings-as-errors=on"
+
+apt-get update
+which sudo | apt-get install -y sudo
+echo "Install packages"
+sudo apt install -y $PACKAGES
+mkdir -p /opt/github
+cd /opt/github
+if [ ! -d histogram ]; then
+  git clone $LIBRARY_URL
+  cd $LIBRARY
+else
+  cd $LIBRARY
+  git fetch origin
+fi
+
+echo "Setup Boost"
+# echo GITHUB_REPOSITORY: $GITHUB_REPOSITORY
+# LIBRARY=${GITHUB_REPOSITORY#*/}
+echo LIBRARY: $LIBRARY
+# echo "LIBRARY=$LIBRARY" >> $GITHUB_ENV
+# echo GITHUB_BASE_REF: $GITHUB_BASE_REF
+# echo GITHUB_REF: $GITHUB_REF
+# REF=${GITHUB_BASE_REF:-$GITHUB_REF}
+# REF=${REF#refs/heads/}
+# echo REF: $REF
+GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+BOOST_BRANCH=develop && [ "$GIT_BRANCH" == "master" ] && BOOST_BRANCH=master || true
+echo BOOST_BRANCH: $BOOST_BRANCH
+cd ..
+if [ ! -d boost-root ]; then
+  git clone -b $BOOST_BRANCH --depth 1 --no-single-branch https://github.com/boostorg/boost.git boost-root
+  cd boost-root
+else
+  cd boost-root
+  git checkout $BOOST_BRANCH
+  git pull
+fi
+BOOST_ROOT=`pwd`
+
+cp -r $GITHUB_WORKSPACE/* libs/$LIBRARY
+git submodule update --init tools/boostdep
+python3 tools/boostdep/depinst/depinst.py --git_args "--jobs 3" $LIBRARY
+./bootstrap.sh
+./b2 -d0 headers
+
+if [ -n "$COMPILER" ]; then
+  echo "Create user-config.jam"
+  echo "using $TOOLSET : : $COMPILER ;" > ~/user-config.jam
+fi
+
+./b2 -j3 libs/$LIBRARY/test//all toolset=$TOOLSET cxxstd=latest coverage=on
+
+echo "Process coverage data"
+cd libs/$LIBRARY
+tools/cov.sh
+
+if [ -n "$COVERALLS_REPO_TOKEN" ]; then
+  echo "Uploading results to coveralls.io"
+  export DEBIAN_FRONTEND=noninteractive
+  sudo apt-get install -y npm
+  npm install coveralls
+  cat coverage.info | node_modules/.bin/coveralls
+fi


### PR DESCRIPTION
Hi,

Some info about the changes:
- upgrade lcov from 1.14 to 1.15
- adds support for lcov with gcc-9 and gcc-10.  However, lcov 1.15 processing gcc-9 and 10 is rather slow.
- gcov ideally shouldn't be hardcoded to version 8. Rather, match the gcc version. Thus, GCOVTOOL='gcov-4.6' for gcc-4.6, or GCOVTOOL='gcov-6' for gcc-6.
- btw, the new cov.yml file was based on https://github.com/boostorg/boost-ci/blob/master/ci.yml, which is a generic GHA file that pdimov wrote to use with any boost library.

> I also want to generate coverage data offline.

That should be fairly simple, by running the same CI scripts on a local machine.   I will test it out, and send over the steps.
