### PR TITLE
fix scaling for count

### DIFF
--- a/.github/workflows/cov.yml
+++ b/.github/workflows/cov.yml
@@ -12,10 +12,11 @@ on:
 
 env:
   B2_OPTS: -q -j2 warnings-as-errors=on
+  GCC_VERSION: 11
 
 jobs:
   cov:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v2
     - name: Fetch Boost superproject
@@ -49,12 +50,12 @@ jobs:
         cd libs/histogram
 
         # don't compile examples in coverage build, coverage must come from tests alone
-        ../../b2 $B2_OPTS toolset=gcc-8 cxxstd=latest coverage=on test//all
+        ../../b2 $B2_OPTS toolset=gcc-${GCC_VERSION} cxxstd=latest coverage=on test//all
 
     - name: Process coverage data
       run: |
         cd libs/histogram
-        GCOV=gcov-8 tools/cov.py
+        GCOV=gcov-${GCC_VERSION} tools/cov.py
 
     - uses: coverallsapp/github-action@v1.1.2
       with:

--- a/.github/workflows/cov.yml
+++ b/.github/workflows/cov.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   cov:
-    runs-on: macos-11
+    runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
     - name: Fetch Boost superproject

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -37,5 +37,5 @@ jobs:
     - name: ctest
       run: |
         cd build
-        make tests # temporary workaround (I hope)
+        make -j3 tests # temporary workaround (I hope)
         ctest -C Debug --output-on-failure

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -37,5 +37,5 @@ jobs:
     - name: ctest
       run: |
         cd build
-        make -j3 tests # temporary workaround (I hope)
+        cmake --build . -j3 --target tests # temporary workaround (I hope)
         ctest -C Debug --output-on-failure

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -37,4 +37,5 @@ jobs:
     - name: ctest
       run: |
         cd build
+        make tests # temporary workaround (I hope)
         ctest -C Debug --output-on-failure

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -107,7 +107,7 @@ jobs:
         cd libs/histogram
         ../../b2 $B2_OPTS toolset=gcc-10 cxxstd=20 cxxflags="-O3 -funsafe-math-optimizations" test//all examples
 
-  clang6:
+  clang10:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -127,4 +127,4 @@ jobs:
     - name: Test cxxstd=17 ubsan asan
       run: |
         cd libs/histogram
-        ../../b2 $B2_OPTS toolset=clang-6 cxxstd=17 variant=histogram_ubasan test//all
+        ../../b2 $B2_OPTS toolset=clang-10 cxxstd=17 variant=histogram_ubasan test//all

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 
   include(CTest)
   add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -C $<CONFIG>)
+  add_dependencies(check tests) # needed to build the "run" tests
 
   if(BUILD_TESTING)
 

--- a/include/boost/histogram/detail/atomic_number.hpp
+++ b/include/boost/histogram/detail/atomic_number.hpp
@@ -42,6 +42,12 @@ struct atomic_number : std::atomic<T> {
     return *this;
   }
 
+  // not thread-safe
+  atomic_number& operator*=(const T& x) noexcept {
+    this->store(this->load() * x);
+    return *this;
+  }
+
 private:
   // for integral types
   template <class U = T>

--- a/include/boost/histogram/histogram.hpp
+++ b/include/boost/histogram/histogram.hpp
@@ -279,7 +279,7 @@ public:
     detail::sample_args_passed_vs_expected<sample_args_passed,
                                            typename acc_traits::args>();
     std::lock_guard<typename mutex_base::type> guard{mutex_base::get()};
-    mp11::tuple_apply(
+    mp11::tuple_apply( // LCOV_EXCL_LINE: gcc-11 is missing this line for no reason
         [&](const auto&... sargs) {
           constexpr bool sample_valid =
               std::is_convertible<sample_args_passed, typename acc_traits::args>::value;
@@ -309,7 +309,7 @@ public:
     detail::sample_args_passed_vs_expected<sample_args_passed,
                                            typename acc_traits::args>();
     std::lock_guard<typename mutex_base::type> guard{mutex_base::get()};
-    mp11::tuple_apply(
+    mp11::tuple_apply( // LCOV_EXCL_LINE: gcc-11 is missing this line for no reason
         [&](const auto&... sargs) {
           constexpr bool weight_valid = acc_traits::weight_support;
           static_assert(weight_valid, "error: accumulator does not support weights");

--- a/test/accumulators_count_test.cpp
+++ b/test/accumulators_count_test.cpp
@@ -17,28 +17,38 @@ template <class T, bool B>
 void run_tests() {
   using c_t = accumulators::count<T, B>;
 
-  c_t c;
-  ++c;
-  BOOST_TEST_EQ(c.value(), 1);
-  BOOST_TEST_EQ(str(c), "1"s);
-  BOOST_TEST_EQ(str(c, 2, false), " 1"s);
-  BOOST_TEST_EQ(str(c, 2, true), "1 "s);
+  {
+    c_t c;
+    ++c;
+    BOOST_TEST_EQ(c.value(), 1);
+    BOOST_TEST_EQ(str(c), "1"s);
+    BOOST_TEST_EQ(str(c, 2, false), " 1"s);
+    BOOST_TEST_EQ(str(c, 2, true), "1 "s);
 
-  c += 2;
-  BOOST_TEST_EQ(str(c), "3"s);
+    c += 2;
+    BOOST_TEST_EQ(str(c), "3"s);
 
-  BOOST_TEST_EQ(c, static_cast<T>(3));
-  BOOST_TEST_NE(c, static_cast<T>(2));
+    BOOST_TEST_EQ(c, static_cast<T>(3));
+    BOOST_TEST_NE(c, static_cast<T>(2));
+  }
 
-  c_t one(1), two(2), one_copy(1);
-  BOOST_TEST_LT(one, two);
-  BOOST_TEST_LE(one, two);
-  BOOST_TEST_LE(one, one_copy);
-  BOOST_TEST_GT(two, one);
-  BOOST_TEST_GE(two, one);
-  BOOST_TEST_GE(one, one_copy);
+  {
+    c_t one(1), two(2), one_copy(1);
+    BOOST_TEST_LT(one, two);
+    BOOST_TEST_LE(one, two);
+    BOOST_TEST_LE(one, one_copy);
+    BOOST_TEST_GT(two, one);
+    BOOST_TEST_GE(two, one);
+    BOOST_TEST_GE(one, one_copy);
+  }
 
   BOOST_TEST_EQ(c_t{} += c_t{}, c_t{});
+
+  {
+    c_t two(2);
+    auto six = two * 3;
+    BOOST_TEST_EQ(six, static_cast<T>(6));
+  }
 }
 
 int main() {

--- a/tools/cov.py
+++ b/tools/cov.py
@@ -18,7 +18,7 @@ import sys
 
 LCOV_VERSION = "1.15"
 
-gcov = os.environ.get("GCOV", "gcov-8")
+gcov = os.environ.get("GCOV", "gcov")
 
 gcov_version = gcov.split("-")[1] if "-" in gcov else None
 gcc_version = f"gcc-{gcov_version}" if gcov_version else "gcc"


### PR DESCRIPTION
accumulators::count was missing a test for scaling and did not work when the second parameter was true. Proper scaling is now implemented (thanks to @henryiii for reporting this).

The rest of this patch repairs the CI system.