### PR TITLE
tests: explicit extensions required in modern CMake

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -17,7 +17,7 @@ function(add_benchmark NAME)
     message(AUTHOR_WARNING "add_benchmark: extra arguments ignored: ${__UNPARSED_ARGUMENTS}")
   endif()
 
-  set(SOURCE ${NAME})
+  set(SOURCE ${NAME}.cpp)
   set(NAME benchmark_${NAME})
 
   if(DEFINED BUILD_TESTING AND NOT BUILD_TESTING)


### PR DESCRIPTION
This produces warnings (and would produce errors if the upper limit was changed to 3.21 from the current 3.16). The correct fix is to be explicit.

Example warning:

```
CMake Warning (dev) at benchmark/CMakeLists.txt:27 (add_executable):
  Policy CMP0115 is not set: Source file extensions must be explicit.  Run
  "cmake --help-policy CMP0115" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  File:

    /Users/henryschreiner/git/software/histogram/benchmark/axis_size.cpp
Call Stack (most recent call first):
  benchmark/CMakeLists.txt:34 (add_benchmark)
This warning is for project developers.  Use -Wno-dev to suppress it.
```