### PR TITLE
Do not use the names 'large' and 'small' in sum.hpp

### DIFF
--- a/include/boost/histogram/accumulators/ostream.hpp
+++ b/include/boost/histogram/accumulators/ostream.hpp
@@ -63,7 +63,7 @@ std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>&
 template <class CharT, class Traits, class U>
 std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>& os,
                                               const sum<U>& x) {
-  if (os.width() == 0) return os << "sum(" << x.large() << " + " << x.small() << ")";
+  if (os.width() == 0) return os << "sum(" << x.large_part() << " + " << x.small_part() << ")";
   return detail::handle_nonzero_width(os, x);
 }
 

--- a/include/boost/histogram/accumulators/sum.hpp
+++ b/include/boost/histogram/accumulators/sum.hpp
@@ -43,11 +43,11 @@ public:
 
   /// Allow implicit conversion from sum<T>
   template <class T>
-  sum(const sum<T>& s) noexcept : sum(s.large(), s.small()) {}
+  sum(const sum<T>& s) noexcept : sum(s.large_part(), s.small_part()) {}
 
   /// Initialize sum explicitly with large and small parts
-  sum(const_reference large, const_reference small) noexcept
-      : large_(large), small_(small) {}
+  sum(const_reference large_part, const_reference small_part) noexcept
+      : large_part_(large_part), small_part_(small_part) {}
 
   /// Increment sum by one
   sum& operator++() noexcept { return operator+=(1); }
@@ -58,64 +58,64 @@ public:
     // when -ffast-math is enabled
     volatile value_type l;
     value_type s;
-    if (std::abs(large_) >= std::abs(value)) {
-      l = large_;
+    if (std::abs(large_part_) >= std::abs(value)) {
+      l = large_part_;
       s = value;
     } else {
       l = value;
-      s = large_;
+      s = large_part_;
     }
-    large_ += value;
-    l = l - large_;
+    large_part_ += value;
+    l = l - large_part_;
     l = l + s;
-    small_ += l;
+    small_part_ += l;
     return *this;
   }
 
   /// Add another sum
   sum& operator+=(const sum& s) noexcept {
-    operator+=(s.large_);
-    small_ += s.small_;
+    operator+=(s.large_part_);
+    small_part_ += s.small_part_;
     return *this;
   }
 
   /// Scale by value
   sum& operator*=(const_reference value) noexcept {
-    large_ *= value;
-    small_ *= value;
+    large_part_ *= value;
+    small_part_ *= value;
     return *this;
   }
 
   bool operator==(const sum& rhs) const noexcept {
-    return large_ + small_ == rhs.large_ + rhs.small_;
+    return large_part_ + small_part_ == rhs.large_part_ + rhs.small_part_;
   }
 
   bool operator!=(const sum& rhs) const noexcept { return !operator==(rhs); }
 
   /// Return value of the sum.
-  value_type value() const noexcept { return large_ + small_; }
+  value_type value() const noexcept { return large_part_ + small_part_; }
 
   /// Return large part of the sum.
-  const_reference large() const noexcept { return large_; }
+  const_reference large_part() const noexcept { return large_part_; }
 
   /// Return small part of the sum.
-  const_reference small() const noexcept { return small_; }
+  const_reference small_part() const noexcept { return small_part_; }
 
   // lossy conversion to value type must be explicit
   explicit operator value_type() const noexcept { return value(); }
 
   template <class Archive>
   void serialize(Archive& ar, unsigned /* version */) {
-    ar& make_nvp("large", large_);
-    ar& make_nvp("small", small_);
+    ar& make_nvp("large_part", large_part_);
+    ar& make_nvp("small_part", small_part_);
   }
 
   // begin: extra operators to make sum behave like a regular number
 
   sum& operator*=(const sum& rhs) noexcept {
     const auto scale = static_cast<value_type>(rhs);
-    large_ *= scale;
-    small_ *= scale;
+    large_part_ *= scale;
+    small_part_ *= scale;
     return *this;
   }
 
@@ -127,8 +127,8 @@ public:
 
   sum& operator/=(const sum& rhs) noexcept {
     const auto scale = 1.0 / static_cast<value_type>(rhs);
-    large_ *= scale;
-    small_ *= scale;
+    large_part_ *= scale;
+    small_part_ *= scale;
     return *this;
   }
 
@@ -157,8 +157,8 @@ public:
   // end: extra operators
 
 private:
-  value_type large_{};
-  value_type small_{};
+  value_type large_part_{};
+  value_type small_part_{};
 };
 
 } // namespace accumulators


### PR DESCRIPTION
Sadly, we have a problem building against histogram on MSVC with the Visual Studio v2019 compiler and also with the ClangCl 12.0.1 frontend compiler. The problem comes from Microsoft header `C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\shared\rpcndr.h` that defines the name `small`:
```
C:\Debug\include\boost/histogram/accumulators/sum.hpp(49,46): error: cannot combine with previous 'type-name' declaration specifier
  sum(const_reference large, const_reference small) noexcept

C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\shared\rpcndr.h(190,15): note: expanded from macro 'small'
#define small char
```

Basically the build breaks when including `windows.h` in addition to the boost histogram algorithms. We tried the various defines that make `windows.h` lean and mean, but none of this helped.

This PR just renames `small` and `large` in sum.hpp to `small_part` and `large_part`, which I hope are also good names? Of course the real culprit here is the MSVC header, but it would be great to just get this resolved in boost histogram instead of other workarounds that fight the Microsoft defines...