### PR TITLE
Update metadata

### DIFF
--- a/meta/libraries.json
+++ b/meta/libraries.json
@@ -1,6 +1,6 @@
 {
     "key": "histogram",
-    "name": "histogram",
+    "name": "Histogram",
     "authors": [
         "Hans Dembinski"
     ],


### PR DESCRIPTION
In the metadata, the name field is generally being used verbatim to display the library name, even including capitalization.   Compare to other boost libraries...
