### PR TITLE
fix ci build

### DIFF
--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -37,4 +37,4 @@ jobs:
     - name: test
       run: |
         cd build
-        cmake --build . --target check -j3 -- -k
+        cmake --build . --target check -j3

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -29,13 +29,12 @@ jobs:
       fail-fast: true
     steps:
     - uses: actions/checkout@v2
-    - name: cmake
+    - name: prepare build
       run: |
         mkdir build
         cd build
-        cmake ..
-    - name: ctest
+        cmake -DCMAKE_BUILD_TYPE=Debug ..
+    - name: test
       run: |
         cd build
-        cmake --build . --target tests -j3 -- -k
-        ctest -C Debug --output-on-failure
+        cmake --build . --target check -j3 -- -k

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -34,8 +34,8 @@ jobs:
     - name: CMake from superproject
       run: |
         cd ..
-        cmake -DBOOST_ENABLE_CMAKE=1 -DBoost_VERBOSE=1 $GITHUB_WORKSPACE
-        ctest -j2 --output-on-failure -R boost_histogram
+        cmake -DBoost_VERBOSE=1 $GITHUB_WORKSPACE
+        cmake --build . --target all -j3 -- -k
 
   appleclang:
     runs-on: macos-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 
     set(BUILD_TESTING OFF) # do not build tests of dependencies
 
+    boost_fetch(boostorg/static_assert TAG develop EXCLUDE_FROM_ALL)
     boost_fetch(boostorg/assert TAG develop EXCLUDE_FROM_ALL) # needed by core
     boost_fetch(boostorg/config TAG develop EXCLUDE_FROM_ALL)
     boost_fetch(boostorg/core TAG develop EXCLUDE_FROM_ALL)


### PR DESCRIPTION
Closes #347 

#### Changes to cmake builds
- Superproject build cannot run tests anymore, so now it is a simple build test for the superproject
- Tests need to be compiled with `make check` to work or rather `cmake --build . --target check`, `-k` option does not work on windows so it was removed