### PR TITLE
Division support for weighted_sum

### DIFF
--- a/include/boost/histogram/accumulators/weighted_sum.hpp
+++ b/include/boost/histogram/accumulators/weighted_sum.hpp
@@ -8,6 +8,7 @@
 #define BOOST_HISTOGRAM_ACCUMULATORS_WEIGHTED_SUM_HPP
 
 #include <boost/core/nvp.hpp>
+#include <boost/histogram/detail/square.hpp>
 #include <boost/histogram/fwd.hpp> // for weighted_sum<>
 #include <type_traits>
 
@@ -46,7 +47,7 @@ public:
   /// Increment by weight.
   weighted_sum& operator+=(const weight_type<value_type>& w) {
     sum_of_weights_ += w.value;
-    sum_of_weights_squared_ += w.value * w.value;
+    sum_of_weights_squared_ += detail::square(w.value);
     return *this;
   }
 
@@ -66,8 +67,8 @@ public:
     sum_of_weights_ /= rv;
     // error propagation for independent a, b:
     // c = a / b: var(c) = (var(a)/a^2 + var(b)/b^2) c^2
-    sum_of_weights_squared_ =
-        (w / (v * v) + rw / (rv * rv)) * sum_of_weights_ * sum_of_weights_;
+    using detail::square;
+    sum_of_weights_squared_ = (w / square(v) + rw / square(rv)) * square(sum_of_weights_);
     return *this;
   }
 

--- a/include/boost/histogram/accumulators/weighted_sum.hpp
+++ b/include/boost/histogram/accumulators/weighted_sum.hpp
@@ -57,6 +57,20 @@ public:
     return *this;
   }
 
+  /// Divide by another weighted sum.
+  weighted_sum& operator/=(const weighted_sum& rhs) {
+    const auto v = sum_of_weights_;
+    const auto w = sum_of_weights_squared_;
+    const auto rv = rhs.sum_of_weights_;
+    const auto rw = rhs.sum_of_weights_squared_;
+    sum_of_weights_ /= rv;
+    // error propagation for independent a, b:
+    // c = a / b: var(c) = (var(a)/a^2 + var(b)/b^2) c^2
+    sum_of_weights_squared_ =
+        (w / (v * v) + rw / (rv * rv)) * sum_of_weights_ * sum_of_weights_;
+    return *this;
+  }
+
   /// Scale by value.
   weighted_sum& operator*=(const_reference x) {
     sum_of_weights_ *= x;

--- a/test/accumulators_weighted_sum_test.cpp
+++ b/test/accumulators_weighted_sum_test.cpp
@@ -8,6 +8,7 @@
 #include <boost/histogram/accumulators/ostream.hpp>
 #include <boost/histogram/accumulators/sum.hpp>
 #include <boost/histogram/accumulators/weighted_sum.hpp>
+#include <boost/histogram/detail/square.hpp>
 #include <boost/histogram/weight.hpp>
 #include <sstream>
 #include "throw_exception.hpp"
@@ -17,8 +18,6 @@ using namespace boost::histogram;
 using namespace std::literals;
 
 using w_t = accumulators::weighted_sum<double>;
-
-inline double sqr(double x) { return x * x; }
 
 int main() {
   {
@@ -92,8 +91,9 @@ int main() {
     BOOST_TEST_EQ(c.value(), 0.5);
     // error propagation for independent a and b:
     // var(c)/c^2 = var(a)/a^2 + var(b)/b^2
-    BOOST_TEST_EQ(c.variance() / sqr(c.value()),
-                  a.variance() / sqr(a.value()) + b.variance() / sqr(b.value()));
+    BOOST_TEST_EQ(c.variance() / detail::square(c.value()),
+                  a.variance() / detail::square(a.value()) +
+                      b.variance() / detail::square(b.value()));
   }
 
   // division with implicit conversion
@@ -105,8 +105,9 @@ int main() {
     c /= b;
 
     BOOST_TEST_EQ(c.value(), 0.5);
-    // var(b) = b^2
-    BOOST_TEST_EQ(c.variance() / sqr(c.value()), a.variance() / sqr(a.value()) + 1.0 / b);
+    // var(b) = b
+    BOOST_TEST_EQ(c.variance() / detail::square(c.value()),
+                  a.variance() / detail::square(a.value()) + 1.0 / b);
   }
 
   return boost::report_errors();

--- a/test/accumulators_weighted_sum_test.cpp
+++ b/test/accumulators_weighted_sum_test.cpp
@@ -16,9 +16,12 @@
 using namespace boost::histogram;
 using namespace std::literals;
 
+using w_t = accumulators::weighted_sum<double>;
+
+inline double sqr(double x) { return x * x; }
+
 int main() {
   {
-    using w_t = accumulators::weighted_sum<double>;
     w_t w;
     BOOST_TEST_EQ(str(w), "weighted_sum(0, 0)"s);
     BOOST_TEST_EQ(str(w, 20, false), "  weighted_sum(0, 0)"s);
@@ -76,6 +79,34 @@ int main() {
     BOOST_TEST_EQ(w.variance(), 2e200);
 
     BOOST_TEST_EQ(s_t() += s_t(), s_t());
+  }
+
+  // division 1
+  {
+    w_t a{1, 2};
+    w_t b{2, 3};
+
+    auto c = a;
+    c /= b;
+
+    BOOST_TEST_EQ(c.value(), 0.5);
+    // error propagation for independent a and b:
+    // var(c)/c^2 = var(a)/a^2 + var(b)/b^2
+    BOOST_TEST_EQ(c.variance() / sqr(c.value()),
+                  a.variance() / sqr(a.value()) + b.variance() / sqr(b.value()));
+  }
+
+  // division with implicit conversion
+  {
+    w_t a{1, 2};
+    double b = 2;
+
+    auto c = a;
+    c /= b;
+
+    BOOST_TEST_EQ(c.value(), 0.5);
+    // var(b) = b^2
+    BOOST_TEST_EQ(c.variance() / sqr(c.value()), a.variance() / sqr(a.value()) + 1.0 / b);
   }
 
   return boost::report_errors();


### PR DESCRIPTION
Closes #345 

This adds `operator/=` for `weighted_sum`, which is automatically picked up by `histogram::operator/=` and `histogram::operator/` if it is implemented in the accumulator. The variance of the result is computed under the assumption that both histograms contain uncorrelated data.

This will not give the correct answer for efficiencies, where the numerator is a subset of the denominator. We will implement special efficiency accumulators (see #178) for this task.