### PR TITLE
Run ascii tests on windows

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -83,6 +83,9 @@ boost_test(TYPE run SOURCES histogram_mixed_test.cpp)
 boost_test(TYPE run SOURCES histogram_operators_test.cpp
   COMPILE_OPTIONS $<$<CXX_COMPILER_ID:MSVC>:/bigobj>)
 boost_test(TYPE run SOURCES histogram_ostream_test.cpp)
+boost_test(TYPE run SOURCES histogram_ostream_ascii_test.cpp)
+set_tests_properties(run-boost_histogram-histogram_ostream_ascii_test_cpp
+  PROPERTIES ENVIRONMENT "LANG=FOO;COLUMNS=20")
 boost_test(TYPE run SOURCES histogram_test.cpp)
 boost_test(TYPE run SOURCES indexed_test.cpp)
 boost_test(TYPE run SOURCES storage_adaptor_test.cpp)
@@ -124,10 +127,6 @@ endif()
 #     LINK_LIBRARIES Boost::serialization)
 # boost_test(TYPE run SOURCES accumulators_serialization_test.cpp
 #     LINK_LIBRARIES Boost::serialization)
-
-boost_test(TYPE run SOURCES histogram_ostream_ascii_test.cpp)
-set_tests_properties(run-boost_histogram-histogram_ostream_ascii_test_cpp
-  PROPERTIES ENVIRONMENT "LANG=FOO;COLUMNS=20")
 
 # Workaround for gcc-5
 if (NOT(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6))

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -150,18 +150,23 @@ alias libserial :
     <link>static <warnings>off <rtti>on
     ;
 
+# helper for minimal and develop aliases
+alias minimal_without_failure : cxx14 cxx17 threading odr ;
+
 # for builds without optional boost dependencies
-alias minimal : cxx14 cxx17 failure threading ;
+alias minimal : minimal_without_failure failure ;
 
 # for builds with optional boost dependencies
 alias optional_boost : accumulators range units serialization ;
 
 # all tests
-alias all : minimal odr optional_boost ;
+alias all : minimal optional_boost ;
 
-# all except "failure", because it is distracting during development
-alias develop : odr cxx14 cxx17 threading optional_boost ;
+# all except "failure", because it is distracting during development;
+# this is called implicitly if no other alias is specified
+alias develop : minimal_without_failure optional_boost ;
 
+explicit minimal_without_failure ;
 explicit minimal ;
 explicit all ;
 explicit odr ;

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -89,6 +89,8 @@ alias cxx14 :
     [ run utility_test.cpp ]
     [ run issue_327_test.cpp ]
     [ run issue_353_test.cpp ]
+    [ run histogram_ostream_test.cpp : : : <testing.launcher>"set LANG=UTF" ]
+    [ run histogram_ostream_ascii_test.cpp : : : <testing.launcher>"set LANG=FOO COLUMNS=20" ]
     ;
 
 alias cxx17 :
@@ -128,12 +130,6 @@ alias threading :
     <threading>multi
     ;
 
-# tests do not work on windows, because environment variables cannot be set
-alias not_windows :
-    [ run histogram_ostream_test.cpp : : : <testing.launcher>"LANG=UTF" ]
-    [ run histogram_ostream_ascii_test.cpp : : : <testing.launcher>"LANG=FOO COLUMNS=20" ]
-    ;
-
 # warnings are off for these other boost libraries, which tend to be not warning-free
 alias accumulators : [ run boost_accumulators_support_test.cpp ] : <warnings>off ;
 alias range : [ run boost_range_support_test.cpp ] : <warnings>off ;
@@ -161,10 +157,10 @@ alias minimal : cxx14 cxx17 failure threading ;
 alias optional_boost : accumulators range units serialization ;
 
 # all tests
-alias all : minimal not_windows odr optional_boost ;
+alias all : minimal odr optional_boost ;
 
 # all except "failure", because it is distracting during development
-alias develop : odr cxx14 cxx17 threading not_windows optional_boost ;
+alias develop : odr cxx14 cxx17 threading optional_boost ;
 
 explicit minimal ;
 explicit all ;
@@ -173,7 +169,6 @@ explicit cxx14 ;
 explicit cxx17 ;
 explicit failure ;
 explicit threading ;
-explicit not_windows ;
 explicit accumulators ;
 explicit range ;
 explicit units ;


### PR DESCRIPTION
I finally figured out the platform independent way to set environment variables for tests in both cmake and b2, so histogram_ostream_ascii tests can be enabled on all platforms.