### PR TITLE
Use `std::is_same` instead of `boost::core::is_same`

### DIFF
--- a/test/histogram_operators_test.cpp
+++ b/test/histogram_operators_test.cpp
@@ -4,7 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/core/is_same.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
 #include <boost/histogram/axis.hpp>
@@ -15,6 +14,7 @@
 #include <boost/throw_exception.hpp>
 #include <string>
 #include <vector>
+#include <type_traits>
 #include "dummy_storage.hpp"
 #include "histogram.hpp"
 #include "std_ostream.hpp"
@@ -74,7 +74,7 @@ void run_tests() {
     BOOST_TEST_EQ(d3.at(2), 81);
 
     auto d4 = d3 * (1 * d); // converted return type
-    BOOST_TEST_TRAIT_FALSE((boost::core::is_same<decltype(d4), decltype(d3)>));
+    BOOST_TEST_TRAIT_FALSE((std::is_same<decltype(d4), decltype(d3)>));
     BOOST_TEST_EQ(d4.at(0), 8);
     BOOST_TEST_EQ(d4.at(1), 27);
     d4 /= d;
@@ -86,8 +86,8 @@ void run_tests() {
 
     auto e = 3 * a; // converted return type
     auto f = b * 2; // converted return type
-    BOOST_TEST_TRAIT_FALSE((boost::core::is_same<decltype(e), decltype(a)>));
-    BOOST_TEST_TRAIT_FALSE((boost::core::is_same<decltype(f), decltype(a)>));
+    BOOST_TEST_TRAIT_FALSE((std::is_same<decltype(e), decltype(a)>));
+    BOOST_TEST_TRAIT_FALSE((std::is_same<decltype(f), decltype(a)>));
     BOOST_TEST_EQ(e.at(0), 3);
     BOOST_TEST_EQ(e.at(1), 0);
     BOOST_TEST_EQ(f.at(0), 0);


### PR DESCRIPTION
`boost::core::is_same` is deprecated, so use `std::is_same` instead.