### PR TITLE
add parentheses around min and max

### DIFF
--- a/include/boost/histogram/detail/axes.hpp
+++ b/include/boost/histogram/detail/axes.hpp
@@ -236,7 +236,7 @@ bool axes_equal_impl(const T& t, const U& u, mp11::index_sequence<Is...>) noexce
 template <class... Ts, class... Us>
 bool axes_equal_impl(const std::tuple<Ts...>& t, const std::tuple<Us...>& u) noexcept {
   return axes_equal_impl(
-      t, u, mp11::make_index_sequence<std::min(sizeof...(Ts), sizeof...(Us))>{});
+      t, u, mp11::make_index_sequence<(std::min)(sizeof...(Ts), sizeof...(Us))>{});
 }
 
 template <class... Ts, class U>

--- a/include/boost/histogram/detail/fill.hpp
+++ b/include/boost/histogram/detail/fill.hpp
@@ -229,7 +229,7 @@ struct linearize_args<S, 1> {
 };
 
 template <class A>
-constexpr unsigned min(const unsigned n) noexcept {
+constexpr unsigned(min)(const unsigned n) noexcept {
   constexpr unsigned a = buffer_size<A>::value;
   return a < n ? a : n;
 }

--- a/include/boost/histogram/detail/fill_n.hpp
+++ b/include/boost/histogram/detail/fill_n.hpp
@@ -218,7 +218,7 @@ void fill_n_nd(const std::size_t offset, S& storage, A& axes, const std::size_t 
   */
 
   for (std::size_t start = 0; start < vsize; start += buffer_size) {
-    const std::size_t n = std::min(buffer_size, vsize - start);
+    const std::size_t n = (std::min)(buffer_size, vsize - start);
     // fill buffer of indices...
     fill_n_indices(indices, start, n, offset, storage, axes, values);
     // ...and fill corresponding storage cells

--- a/include/boost/histogram/indexed.hpp
+++ b/include/boost/histogram/indexed.hpp
@@ -334,8 +334,8 @@ public:
       constexpr axis::index_type start = opt::test(axis::option::underflow) ? -1 : 0;
       const auto stop = size + (opt::test(axis::option::overflow) ? 1 : 0);
 
-      ca->begin = std::max(start, detail::get<0>(*r_begin));
-      ca->end = std::min(stop, detail::get<1>(*r_begin));
+      ca->begin = (std::max)(start, detail::get<0>(*r_begin));
+      ca->end = (std::min)(stop, detail::get<1>(*r_begin));
       assert(ca->begin <= ca->end);
       ca->idx = ca->begin;
 

--- a/include/boost/histogram/ostream.hpp
+++ b/include/boost/histogram/ostream.hpp
@@ -57,7 +57,7 @@ public:
       }
       count_ = 0;
       os_ << t;
-      *iter_ = std::max(*iter_, static_cast<int>(count_));
+      *iter_ = (std::max)(*iter_, static_cast<int>(count_));
     } else {
       assert(iter_ != end());
       os_ << std::setw(*iter_) << t;
@@ -109,7 +109,7 @@ void ostream_value_impl(OStream& os, const T& t,
                         decltype(static_cast<double>(t), priority<1>{})) {
   // a value from histogram cell
   const auto d = static_cast<double>(t);
-  if (std::numeric_limits<int>::min() <= d && d <= std::numeric_limits<int>::max()) {
+  if ((std::numeric_limits<int>::min)() <= d && d <= (std::numeric_limits<int>::max)()) {
     const auto i = static_cast<int>(d);
     if (i == d) {
       os << i;
@@ -167,7 +167,7 @@ void ostream_bin(OStream& os, const Axis&, axis::index_type i, B, priority<0>) {
 struct line {
   const char* ch;
   const int size;
-  line(const char* a, int b) : ch{a}, size{std::max(b, 0)} {}
+  line(const char* a, int b) : ch{a}, size{(std::max)(b, 0)} {}
 };
 
 template <class T>
@@ -243,8 +243,8 @@ void plot(OStream& os, const Histogram& h, int w_total, std::true_type) {
   for (auto&& v : indexed(h, coverage::all)) {
     auto w = static_cast<double>(*v);
     ostream_head(tos.row(), ax, v.index(), w);
-    vmin = std::min(vmin, w);
-    vmax = std::max(vmax, w);
+    vmin = (std::min)(vmin, w);
+    vmax = (std::max)(vmax, w);
   }
   tos.complete();
   if (vmax == 0) vmax = 1;
@@ -300,7 +300,7 @@ void ostream(OStream& os, const Histogram& h, const bool show_values = true) {
     tos.complete();
 
     const int w_item = std::accumulate(tos.begin(), tos.end(), 0) + 4 + h.rank();
-    const int nrow = std::max(1, 65 / w_item);
+    const int nrow = (std::max)(1, 65 / w_item);
     int irow = 0;
     for (auto&& v : indexed(h, coverage::all)) {
       os << (irow == 0 ? "\n  (" : " (");

--- a/test/histogram_custom_axis_test.cpp
+++ b/test/histogram_custom_axis_test.cpp
@@ -48,7 +48,7 @@ public:
     const auto x = std::get<0>(xy);
     const auto y = std::get<1>(xy);
     const auto r = std::sqrt(x * x + y * y);
-    return std::min(static_cast<axis::index_type>(r), size());
+    return (std::min)(static_cast<axis::index_type>(r), size());
   }
 
   auto update(std::tuple<double, double> xy) {

--- a/test/histogram_fill_test.cpp
+++ b/test/histogram_fill_test.cpp
@@ -53,7 +53,7 @@ struct axis2d {
     const auto x = std::get<0>(xy);
     const auto y = std::get<1>(xy);
     const auto r = std::sqrt(x * x + y * y);
-    return std::min(static_cast<axis::index_type>(r), size());
+    return (std::min)(static_cast<axis::index_type>(r), size());
   }
 
   friend std::ostream& operator<<(std::ostream& os, const axis2d&) {

--- a/test/unlimited_storage_test.cpp
+++ b/test/unlimited_storage_test.cpp
@@ -239,11 +239,11 @@ struct adder {
       // If RHS is normal integer, LHS doesn't change.
       a[0] += b;
       // BOOST_TEST_EQ(unsafe_access::unlimited_storage_buffer(a).type,
-      //               iRHS < 4 ? iLHS : std::max(iLHS, iRHS));
+      //               iRHS < 4 ? iLHS : (std::max)(iLHS, iRHS));
       BOOST_TEST_EQ(a[0], limits_max<RHS>());
       a[0] += prepare<RHS>(1, b)[0];
       // BOOST_TEST_EQ(unsafe_access::unlimited_storage_buffer(a).type,
-      //               iRHS < 4 ? iLHS + 1 : std::max(iLHS, iRHS));
+      //               iRHS < 4 ? iLHS + 1 : (std::max)(iLHS, iRHS));
       BOOST_TEST_EQ(a[0], 2 * double(limits_max<RHS>()));
     }
   }


### PR DESCRIPTION
add parentheses around `min` and `max` to suppress macro invocation
https://stackoverflow.com/questions/6884093/warning-c4003-not-enough-actual-parameters-for-macro-max-visual-studio-2010
https://stackoverflow.com/questions/7449620/how-to-call-stdmin-when-min-has-been-defined-as-a-macro
https://stackoverflow.com/questions/22744262/cant-call-stdmax-because-minwindef-h-defines-max
https://stackoverflow.com/questions/11544073/how-do-i-deal-with-the-max-macro-in-windows-h-colliding-with-max-in-std

