### PR TITLE
Split out dynamic-only tests

### DIFF
--- a/test/algorithm_project_test.cpp
+++ b/test/algorithm_project_test.cpp
@@ -136,6 +136,8 @@ void run_tests() {
   }
 }
 
+// split out dynamic tests as workaround for compiler bug in
+// Visual Studio 2019 14.29.30133 (19.29.30145.0), see PR 388 by Ed Catmur
 void run_dynamic_tests() {
   {
     auto h = make(dynamic_tag(), axis::integer<>(0, 2), axis::integer<>(0, 3));

--- a/test/algorithm_project_test.cpp
+++ b/test/algorithm_project_test.cpp
@@ -134,7 +134,9 @@ void run_tests() {
     BOOST_TEST_EQ(h_210.at(2, 0, 0), 1);
     BOOST_TEST_EQ(h_210.at(2, 0, 1), 1);
   }
+}
 
+void run_dynamic_tests() {
   {
     auto h = make(dynamic_tag(), axis::integer<>(0, 2), axis::integer<>(0, 3));
     h(0, 0);
@@ -188,6 +190,7 @@ void run_tests() {
 int main() {
   run_tests<static_tag>();
   run_tests<dynamic_tag>();
+  run_dynamic_tests();
 
   return boost::report_errors();
 }


### PR DESCRIPTION
Compiling tests under Visual Studio 2019 14.29.30133 (19.29.30145.0) fails with a not very helpful error:
```
libs\histogram\test\algorithm_project_test.cpp(186,1): fatal error C1903: unable to recover from previous error(s); stopping compilation
```
This can be fixed by moving the dynamic-only tests into a separate function, so that they are only compiled and run once.