### PR TITLE
Only use console window size if `ioctl(TIOCGWINSZ)` succeeded.

### DIFF
--- a/include/boost/histogram/detail/term_info.hpp
+++ b/include/boost/histogram/detail/term_info.hpp
@@ -69,9 +69,9 @@ inline bool utf8() {
 inline int width() {
   int w = 0;
 #if defined TIOCGWINSZ
-  struct winsize ws;
-  ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws);
-  w = (std::max)(static_cast<int>(ws.ws_col), 0); // not sure if ws_col can be less than 0
+  struct winsize ws{};
+  if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == 0)
+    w = (std::max)(static_cast<int>(ws.ws_col), 0); // not sure if ws_col can be less than 0
 #endif
   env_t env("COLUMNS");
   const int col = (std::max)(static_cast<int>(env), 0);


### PR DESCRIPTION
This avoids potentially using uninitialized data if `ioctl` fails. Also, zero-initialize the `winsize` struct to begin with.