### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,6 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 
     set(BUILD_TESTING OFF) # do not build tests of dependencies
 
-    boost_fetch(boostorg/static_assert TAG develop EXCLUDE_FROM_ALL)
     boost_fetch(boostorg/config TAG develop EXCLUDE_FROM_ALL)
     boost_fetch(boostorg/core TAG develop EXCLUDE_FROM_ALL)
     boost_fetch(boostorg/mp11 TAG develop EXCLUDE_FROM_ALL)


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.