### PR TITLE
Tests: Change `sample(int)` to `sample(double)` for C++23 compatibility

### DIFF
--- a/test/algorithm_empty_test.cpp
+++ b/test/algorithm_empty_test.cpp
@@ -43,15 +43,15 @@ void run_tests() {
     BOOST_TEST(empty(h, coverage::all));
     BOOST_TEST(empty(h, coverage::inner));
     h.reset();
-    h(weight(2), -2, -4, sample(3));
+    h(weight(2), -2, -4, sample(3.0));
     BOOST_TEST(!empty(h, coverage::all));
     BOOST_TEST(empty(h, coverage::inner));
     h.reset();
-    h(weight(1), -4, 2, sample(2));
+    h(weight(1), -4, 2, sample(2.0));
     BOOST_TEST(!empty(h, coverage::all));
     BOOST_TEST(empty(h, coverage::inner));
     h.reset();
-    h(weight(3), 3, 5, sample(1));
+    h(weight(3), 3, 5, sample(1.0));
     BOOST_TEST(!empty(h, coverage::all));
     BOOST_TEST(!empty(h, coverage::inner));
   }

--- a/test/histogram_custom_axis_test.cpp
+++ b/test/histogram_custom_axis_test.cpp
@@ -85,12 +85,12 @@ void run_tests() {
     BOOST_TEST_EQ(h.at(1), 7);
 
     auto h2 = make_s(Tag(), profile_storage(), axis2d());
-    h2(1, 2, sample(2));
+    h2(1, 2, sample(2.0));
     BOOST_TEST_EQ(h2[1].count(), 1);
     BOOST_TEST_EQ(h2[1].value(), 2);
 
     auto h3 = make_s(Tag(), weighted_profile_storage(), axis2d());
-    h3(1, 2, weight(3), sample(2));
+    h3(1, 2, weight(3), sample(2.0));
     BOOST_TEST_EQ(h3[1].sum_of_weights(), 3);
     BOOST_TEST_EQ(h3[1].value(), 2);
   }

--- a/test/histogram_fill_test.cpp
+++ b/test/histogram_fill_test.cpp
@@ -298,12 +298,12 @@ void run_tests(const std::vector<int>& x, const std::vector<int>& y,
 
     for (unsigned i = 0; i < ndata; ++i) h(x[i], sample(w[i]));
     for (unsigned i = 0; i < ndata; ++i) h(x[i], sample(w[i]), weight(w[i]));
-    for (unsigned i = 0; i < ndata; ++i) h(x[i], sample(2), weight(w[i]));
+    for (unsigned i = 0; i < ndata; ++i) h(x[i], sample(2.0), weight(w[i]));
     for (unsigned i = 0; i < ndata; ++i) h(x[i], sample(w[i]), weight(2));
 
     h2.fill(x, sample(w));
     h2.fill(x, sample(w), weight(w));
-    h2.fill(x, sample(2), weight(w));
+    h2.fill(x, sample(2.0), weight(w));
     h2.fill(x, sample(w), weight(2));
 
     BOOST_TEST_EQ(h, h2);
@@ -315,7 +315,7 @@ void run_tests(const std::vector<int>& x, const std::vector<int>& y,
     auto h2 = h;
 
     for (unsigned i = 0; i < ndata; ++i) h(x[i], 3, sample(w[i]), weight(w[i]));
-    for (unsigned i = 0; i < ndata; ++i) h(x[i], 3, sample(2), weight(w[i]));
+    for (unsigned i = 0; i < ndata; ++i) h(x[i], 3, sample(2.0), weight(w[i]));
     for (unsigned i = 0; i < ndata; ++i) h(x[i], 3, sample(w[i]), weight(2));
 
     using V = variant<int, std::vector<int>>;
@@ -323,7 +323,7 @@ void run_tests(const std::vector<int>& x, const std::vector<int>& y,
     xy[0] = x;
     xy[1] = 3;
     h2.fill(xy, sample(w), weight(w));
-    h2.fill(xy, sample(2), weight(w));
+    h2.fill(xy, sample(2.0), weight(w));
     h2.fill(xy, sample(w), weight(2));
 
     BOOST_TEST_EQ(h, h2);

--- a/test/histogram_test.cpp
+++ b/test/histogram_test.cpp
@@ -284,12 +284,12 @@ void run_tests() {
   {
     auto h = make_s(Tag(), profile_storage(), axis::integer<>(0, 2));
 
-    h(0, sample(1));
-    h(0, sample(2));
-    h(0, sample(3));
-    h(sample(4), 1);
-    h(sample(5), 1);
-    h(sample(6), 1);
+    h(0, sample(1.0));
+    h(0, sample(2.0));
+    h(0, sample(3.0));
+    h(sample(4.0), 1);
+    h(sample(5.0), 1);
+    h(sample(6.0), 1);
 
     BOOST_TEST_EQ(h[0].count(), 3);
     BOOST_TEST_EQ(h[0].value(), 2);
@@ -303,17 +303,17 @@ void run_tests() {
   {
     auto h = make_s(Tag(), weighted_profile_storage(), axis::integer<>(0, 2));
 
-    h(0, sample(1));
-    h(sample(1), 0);
+    h(0, sample(1.0));
+    h(sample(1.0), 0);
 
-    h(0, weight(2), sample(3));
-    h(0, sample(5), weight(2));
+    h(0, weight(2), sample(3.0));
+    h(0, sample(5.0), weight(2));
 
-    h(weight(2), 1, sample(1));
-    h(sample(2), 1, weight(2));
+    h(weight(2), 1, sample(1.0));
+    h(sample(2.0), 1, weight(2));
 
-    h(weight(2), sample(3), 1);
-    h(sample(4), weight(2), 1);
+    h(weight(2), sample(3.0), 1);
+    h(sample(4.0), weight(2), 1);
 
     BOOST_TEST_EQ(h[0].sum_of_weights(), 6);
     BOOST_TEST_EQ(h[0].value(), 3);


### PR DESCRIPTION
I'm the primary maintainer of MSVC's STL. We regularly build popular open-source projects, especially Boost, with development builds of our compiler and libraries to find and fix regressions before they can ship and cause trouble for the world. This also allows us to provide advance notice of breaking changes, which is the case here.

We recently implemented C++23 [P2255R2][] Type Traits To Detect References Binding To Temporaries (e.g. `std::reference_constructs_from_temporary_v` and `std::reference_converts_from_temporary_v`). This was initially supported when using MSVC's STL with Clang 20 (microsoft/STL#5537 merged in Oct 2025, shipping in the [MSVC Build Tools 14.51 Preview][] which was recently released). Very recently, the MSVC compiler implemented the necessary builtins (freshly shipped in MSVC 14.51) and we've merged the library support to activate the type traits (microsoft/STL#6095, available in our repo but not yet shipped in an MSVC Preview).

The paper adding these type traits also updated other parts of the STL to use them, notably `std::tuple`. This can be a source breaking change for code that compiled successfully-but-dangerously in the past. For example, see [N5032][] \[tuple.cnstr\]/23 which specifies `tuple`'s converting constructors and now says:

> ```cpp
> template<class... UTypes> constexpr explicit(see below) tuple(tuple<UTypes...>& u);
> template<class... UTypes> constexpr explicit(see below) tuple(const tuple<UTypes...>& u);
> template<class... UTypes> constexpr explicit(see below) tuple(tuple<UTypes...>&& u);
> template<class... UTypes> constexpr explicit(see below) tuple(const tuple<UTypes...>&& u);
> ```
> *Remarks:* \[...\] The constructor is defined as deleted if
> `(reference_constructs_from_temporary_v<Types, decltype(get<I>(FWD(u)))> || ...)`
> is `true`.

For example, this means that `is_convertible_v<tuple<int>, tuple<const double &>>` is now `false`, because converting from `int` to `const double&` would attempt to bind the `const double&` to a temporary `double`.

(Note that as compilers and Standard Libraries are still catching up, results vary. GCC/libstdc++ 15.2 has implemented this in C++23 mode, and apparently in C++20 mode too, see https://godbolt.org/z/j3GjKnbbG .)

This affects Boost.Histogram because you have some tests that are passing `int` samples, but your machinery wraps them in a `tuple<int>` and later tries to convert to `tuple<const double &>`, which is now forbidden. The compiler errors look like this:

```
C:\Temp>cl /EHsc /nologo /W4 /std:c++latest /MTd /Od /I C:\Temp\boost_1_90_0 C:\Temp\boost_1_90_0\libs\histogram\test\histogram_test.cpp
histogram_test.cpp
C:\Temp\boost_1_90_0\boost/histogram/detail/fill.hpp(48): error C2338: static assertion failed: 'error: sample argument(s) not convertible to accumulator argument(s)'
C:\Temp\boost_1_90_0\boost/histogram/detail/fill.hpp(48): note: the template instantiation context (the oldest one first) is
C:\Temp\boost_1_90_0\libs\histogram\test\histogram_test.cpp(530): note: see reference to function template instantiation 'void run_tests<boost::histogram::static_tag>(void)' being compiled
C:\Temp\boost_1_90_0\libs\histogram\test\histogram_test.cpp(287): note: see reference to function template instantiation 'std::_Vector_iterator<std::_Vector_val<std::_Simple_types<_Ty>>> boost::histogram::histogram<std::tuple<boost::histogram::axis::integer<int,boost::use_default,boost::use_default>>,boost::histogram::make_histogram_with::S>::operator ()<int,boost::histogram::sample_type<std::tuple<int>>,void>(const T0 &,const boost::histogram::sample_type<std::tuple<int>> &)' being compiled
        with
        [
            _Ty=boost::histogram::accumulators::mean<double>,
            T0=int
        ]
C:\Temp\boost_1_90_0\boost/histogram/histogram.hpp(193): note: see reference to function template instantiation 'std::_Vector_iterator<std::_Vector_val<std::_Simple_types<_Ty>>> boost::histogram::histogram<std::tuple<boost::histogram::axis::integer<int,boost::use_default,boost::use_default>>,boost::histogram::make_histogram_with::S>::operator ()<const T0&,const boost::histogram::sample_type<std::tuple<int>>&>(const std::tuple<const T0 &,const boost::histogram::sample_type<std::tuple<int>> &> &)' being compiled
        with
        [
            _Ty=boost::histogram::accumulators::mean<double>,
            T0=int
        ]
C:\Temp\boost_1_90_0\boost/histogram/histogram.hpp(205): note: see reference to class template instantiation 'boost::histogram::detail::sample_args_passed_vs_expected<std::tuple<int>,std::tuple<const double &>>' being compiled
```

I'm unfamiliar with Boost.Histogram's code, but after tracing through the test and product code, the usage of `tuple` looks fundamental to your design, so it looks like the `int` arguments need to be changed to `double`. This PR does that for all of the expected-passing tests I saw in this directory. There are a couple of expected-failing tests that might be affected, but I'm not sure if they should be changed, so I've refrained from that.

Because GCC/libstdc++ 15.2 has implemented this new Standardese, you should be able to fully validate that your tests are fixed (without having to deal with MSVC Previews and building MSVC's STL from our GitHub repo) by using libstdc++ in `-std=c++23` mode. Hope this helps!

[P2255R2]: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2255r2.html
[MSVC Build Tools 14.51 Preview]: https://devblogs.microsoft.com/cppblog/microsoft-c-msvc-build-tools-v14-51-preview-released-how-to-opt-in/
[N5032]: https://isocpp.org/files/papers/N5032.pdf
