### PR TITLE
fix: avoid dangling-reference in sample tuple conversion for C++23 compatibility

### DIFF
--- a/include/boost/histogram/detail/accumulator_traits.hpp
+++ b/include/boost/histogram/detail/accumulator_traits.hpp
@@ -31,24 +31,29 @@ struct accumulator_traits_holder {
 
 // member function pointer with weight_type as first argument is better match
 template <class R, class T, class U, class... Ts>
-accumulator_traits_holder<true, Ts...> accumulator_traits_impl_call_op(
+accumulator_traits_holder<true, std::remove_cv_t<std::remove_reference_t<Ts>>...>
+accumulator_traits_impl_call_op(
     R (T::*)(boost::histogram::weight_type<U>, Ts...));
 
 template <class R, class T, class U, class... Ts>
-accumulator_traits_holder<true, Ts...> accumulator_traits_impl_call_op(
+accumulator_traits_holder<true, std::remove_cv_t<std::remove_reference_t<Ts>>...>
+accumulator_traits_impl_call_op(
     R (T::*)(boost::histogram::weight_type<U>&, Ts...));
 
 template <class R, class T, class U, class... Ts>
-accumulator_traits_holder<true, Ts...> accumulator_traits_impl_call_op(
+accumulator_traits_holder<true, std::remove_cv_t<std::remove_reference_t<Ts>>...>
+accumulator_traits_impl_call_op(
     R (T::*)(boost::histogram::weight_type<U>&&, Ts...));
 
 template <class R, class T, class U, class... Ts>
-accumulator_traits_holder<true, Ts...> accumulator_traits_impl_call_op(
+accumulator_traits_holder<true, std::remove_cv_t<std::remove_reference_t<Ts>>...>
+accumulator_traits_impl_call_op(
     R (T::*)(const boost::histogram::weight_type<U>&, Ts...));
 
 // member function pointer only considered if all specializations above fail
 template <class R, class T, class... Ts>
-accumulator_traits_holder<false, Ts...> accumulator_traits_impl_call_op(R (T::*)(Ts...));
+accumulator_traits_holder<false, std::remove_cv_t<std::remove_reference_t<Ts>>...>
+accumulator_traits_impl_call_op(R (T::*)(Ts...));
 
 template <class T>
 auto accumulator_traits_impl(T&, priority<2>)

--- a/test/accumulators_collector_test.cpp
+++ b/test/accumulators_collector_test.cpp
@@ -30,7 +30,7 @@ bool operator==(const span<T1>& a, const std::vector<T2>& b) {
 int main() {
   using traits = detail::accumulator_traits<accumulators::collector<>>;
   static_assert(!traits::weight_support, "");
-  static_assert(std::is_same<traits::args, std::tuple<const double&>>::value, "");
+  static_assert(std::is_same<traits::args, std::tuple<double>>::value, "");
 
   {
     accumulators::collector<std::vector<int>> acc;

--- a/test/accumulators_mean_test.cpp
+++ b/test/accumulators_mean_test.cpp
@@ -24,7 +24,7 @@ int main() {
 
   using traits = detail::accumulator_traits<m_t>;
   static_assert(traits::weight_support, "");
-  static_assert(std::is_same<traits::args, std::tuple<const double&>>::value, "");
+  static_assert(std::is_same<traits::args, std::tuple<double>>::value, "");
 
   // basic interface, string conversion
   {

--- a/test/detail_accumulator_traits_test.cpp
+++ b/test/detail_accumulator_traits_test.cpp
@@ -72,7 +72,7 @@ int main() {
   };
 
   BOOST_TEST(dtl::accumulator_traits<A7>::weight_support);
-  BOOST_TEST_TRAIT_SAME(typename dtl::accumulator_traits<A7>::args, std::tuple<int&&>);
+  BOOST_TEST_TRAIT_SAME(typename dtl::accumulator_traits<A7>::args, std::tuple<int>);
 
   struct B1 {
     int operator+=(int);


### PR DESCRIPTION
Possible alternative fix for #420.


:robot: Assisted-by: OpenCode:Kimi-K2.6
