### PR TITLE
chore: linting drift

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.12' 
+        python-version: '3.12'
 
     - name: Install docbook dependencies
       run: |

--- a/doc/changelog.qbk
+++ b/doc/changelog.qbk
@@ -48,7 +48,7 @@
 * Replace `detail::span` and `detail::make_span` with implementations in `boost::core`
 * Documentation improvements
 * Protect usage of `std::min` and `std::max` in some cases, contributed by Han Jiang (min,max macros are illegially set by popular Windows headers so we need to work around)
-* Added test to catch usage of unprotected min,max tokens in the library in the future 
+* Added test to catch usage of unprotected min,max tokens in the library in the future
 * Fixes to support latest clang-14 and deduction guides in gcc-11+
 
 [heading Boost 1.81]

--- a/examples/guide_custom_axis_multiple_value_types.cpp
+++ b/examples/guide_custom_axis_multiple_value_types.cpp
@@ -31,9 +31,7 @@ struct my_axis : axis::regular<double> {
     converter_type(double x) : val_{x} {}
   };
 
-  axis::index_type index(converter_type x) const {
-    return base_type::index(x.val_);
-  }
+  axis::index_type index(converter_type x) const { return base_type::index(x.val_); }
 };
 
 int main() {

--- a/examples/guide_fill_histogram.cpp
+++ b/examples/guide_fill_histogram.cpp
@@ -6,8 +6,8 @@
 
 //[ guide_fill_histogram
 
-#include <boost/histogram.hpp>
 #include <boost/core/span.hpp>
+#include <boost/histogram.hpp>
 #include <cassert>
 #include <functional>
 #include <numeric>

--- a/include/boost/histogram/accumulators/collector.hpp
+++ b/include/boost/histogram/accumulators/collector.hpp
@@ -43,7 +43,9 @@ public:
   explicit collector(Args&&... args) : container_(std::forward<Args>(args)...) {}
 
   // make template only match if forwarding args to container is valid
-  template <class T, typename... Args, class = decltype(container_type(std::initializer_list<T>(),std::declval<Args>()...))>
+  template <class T, typename... Args,
+            class = decltype(container_type(std::initializer_list<T>(),
+                                            std::declval<Args>()...))>
   explicit collector(std::initializer_list<T> list, Args&&... args)
       : container_(list, std::forward<Args>(args)...) {}
 

--- a/include/boost/histogram/detail/term_info.hpp
+++ b/include/boost/histogram/detail/term_info.hpp
@@ -69,9 +69,10 @@ inline bool utf8() {
 inline int width() {
   int w = 0;
 #if defined TIOCGWINSZ
-  struct winsize ws{};
+  struct winsize ws {};
   if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == 0)
-    w = (std::max)(static_cast<int>(ws.ws_col), 0); // not sure if ws_col can be less than 0
+    w = (std::max)(static_cast<int>(ws.ws_col),
+                   0); // not sure if ws_col can be less than 0
 #endif
   env_t env("COLUMNS");
   const int col = (std::max)(static_cast<int>(env), 0);

--- a/include/boost/histogram/literals.hpp
+++ b/include/boost/histogram/literals.hpp
@@ -23,7 +23,7 @@ constexpr unsigned parse_number(unsigned n, char f, Rest... rest) {
 namespace literals {
 /// Suffix operator to generate literal compile-time numbers, 0_c, 12_c, etc.
 template <char... digits>
-auto operator ""_c() {
+auto operator""_c() {
   return std::integral_constant<unsigned, detail::parse_number(0, digits...)>();
 }
 } // namespace literals

--- a/include/boost/histogram/utility/clopper_pearson_interval.hpp
+++ b/include/boost/histogram/utility/clopper_pearson_interval.hpp
@@ -54,7 +54,8 @@ public:
     @param successes Number of successful trials.
     @param failures Number of failed trials.
   */
-  interval_type operator()(value_type successes, value_type failures) const noexcept override {
+  interval_type operator()(value_type successes,
+                           value_type failures) const noexcept override {
     // analytical solution when successes or failures are zero
     // T. Mans (2014), Electronic Journal of Statistics. 8 (1): 817-840.
     // arXiv:1303.1288. doi:10.1214/14-EJS909.

--- a/test/detail_array_wrapper_serialization_test.cpp
+++ b/test/detail_array_wrapper_serialization_test.cpp
@@ -25,7 +25,7 @@ struct dummy_array_wrapper {
   std::size_t size;
   template <class Archive>
   void serialize(Archive& ar, unsigned /* version */) {
-    for (auto&& x : boost::make_span(ptr, size)) ar & x;
+    for (auto&& x : boost::make_span(ptr, size)) ar& x;
   }
 };
 


### PR DESCRIPTION
Running `prek -a` on the repo reports changes; this is not being tested in CI, apperently. This is just the result of running the pre-commit hooks without any other changes.
