### PR TITLE
fix: undefined behavior in indexed() for rank-0 histograms

### DIFF
--- a/include/boost/histogram/indexed.hpp
+++ b/include/boost/histogram/indexed.hpp
@@ -253,6 +253,8 @@ public:
       const auto cbeg = indices_.begin();
       auto c = cbeg;
       ++iter_;
+      // rank-0 histogram has a single cell and no indices to update
+      if (c == indices_.end()) return *this;
       ++c->idx;
       if (c->idx < c->end) return *this;
       while (c->idx == c->end) {

--- a/test/algorithm_empty_test.cpp
+++ b/test/algorithm_empty_test.cpp
@@ -4,6 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <algorithm>
 #include <array>
 #include <boost/core/lightweight_test.hpp>
 #include <boost/histogram/accumulators/weighted_mean.hpp>
@@ -60,6 +61,16 @@ void run_tests() {
 int main() {
   run_tests<static_tag>();
   run_tests<dynamic_tag>();
+
+  {
+    // regression test for https://github.com/boostorg/histogram/issues/430
+    auto h = make(dynamic_tag());
+    BOOST_TEST(empty(h, coverage::all));
+    BOOST_TEST(empty(h, coverage::inner));
+    std::fill(h.begin(), h.end(), 1);
+    BOOST_TEST(!empty(h, coverage::all));
+    BOOST_TEST(!empty(h, coverage::inner));
+  }
 
   return boost::report_errors();
 }

--- a/test/algorithm_sum_test.cpp
+++ b/test/algorithm_sum_test.cpp
@@ -75,5 +75,13 @@ int main() {
   run_tests<static_tag>();
   run_tests<dynamic_tag>();
 
+  {
+    // regression test for https://github.com/boostorg/histogram/issues/430
+    auto h = make(dynamic_tag());
+    std::fill(h.begin(), h.end(), 3);
+    BOOST_TEST_EQ(sum(h), 3);
+    BOOST_TEST_EQ(sum(h, coverage::inner), 3);
+  }
+
   return boost::report_errors();
 }

--- a/test/indexed_test.cpp
+++ b/test/indexed_test.cpp
@@ -210,6 +210,29 @@ void run_comparison_tests(Tag) {
   BOOST_TEST(1 >= a);
 }
 
+// regression test for https://github.com/boostorg/histogram/issues/430
+void run_0d_tests(coverage cov) {
+  auto h = make(dynamic_tag());
+  BOOST_TEST_EQ(h.rank(), 0u);
+  BOOST_TEST_EQ(h.size(), 1u);
+  std::fill(h.begin(), h.end(), 2);
+
+  auto ind = indexed(h, cov);
+  auto it = ind.begin();
+  BOOST_TEST(it != ind.end());
+  BOOST_TEST_EQ(it->indices().size(), 0u);
+  BOOST_TEST_EQ(**it, 2);
+  ++it;
+  BOOST_TEST(it == ind.end());
+
+  int count = 0;
+  for (auto&& x : indexed(h, cov)) {
+    BOOST_TEST_EQ(*x, 2);
+    ++count;
+  }
+  BOOST_TEST_EQ(count, 1);
+}
+
 template <class Tag>
 void run_indexed_with_range_tests(Tag) {
   {
@@ -257,6 +280,9 @@ int main() {
 
   run_comparison_tests(static_tag{});
   run_comparison_tests(dynamic_tag{});
+
+  run_0d_tests(coverage::inner);
+  run_0d_tests(coverage::all);
 
   run_indexed_with_range_tests(static_tag{});
   run_indexed_with_range_tests(dynamic_tag{});


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes #430.

For a rank-0 histogram, `indexed_range::iterator::operator++` dereferenced the first slot of the per-axis index buffer, which is empty when there are no axes. That read uninitialized stack memory and, with unlucky stack contents, walked the cell iterator out of bounds — observed as a reproducible segfault on free-threaded Windows via the Python bindings (scikit-hep/boost-histogram#1153).

The fix skips the index update when the index buffer is empty; the single cell of a rank-0 histogram is still visited exactly once, so `indexed()`, `algorithm::sum(h, coverage::inner)`, and `algorithm::empty` now all work for rank 0.

Regression tests cover `indexed()` (both coverages), `sum`, and `empty` on a rank-0 histogram. They pass only by luck without the fix (the uninitialized read is stack-layout dependent and needs MemorySanitizer to detect reliably), but they pin down the intended behavior.