### PR TITLE
chore: move b2 project requirements out of build.jam

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -19,16 +19,7 @@ constant boost_dependencies :
     /boost/throw_exception//boost_throw_exception
     /boost/variant2//boost_variant2 ;
 
-project /boost/histogram
-    : requirements
-        <toolset>clang:<cxxflags>"-Wsign-compare -Wstrict-aliasing -fstrict-aliasing -Wvexing-parse -Wfloat-conversion"
-        <toolset>gcc:<cxxflags>"-Wsign-compare -Wstrict-aliasing -fstrict-aliasing -Wfloat-conversion"
-        <toolset>msvc:<cxxflags>"/bigobj"
-        <toolset>intel-win:<cxxflags>"/bigobj"
-        <local-visibility>hidden
-    : default-build
-        <warnings>extra
-    ;
+project /boost/histogram ;
 
 explicit
     [ alias boost_histogram : : :

--- a/examples/Jamfile
+++ b/examples/Jamfile
@@ -20,6 +20,13 @@ project
       # list could go on...
     ]
     <library>/boost/format//boost_format
+    <toolset>clang:<cxxflags>"-Wsign-compare -Wstrict-aliasing -fstrict-aliasing -Wvexing-parse -Wfloat-conversion"
+    <toolset>gcc:<cxxflags>"-Wsign-compare -Wstrict-aliasing -fstrict-aliasing -Wfloat-conversion"
+    <toolset>msvc:<cxxflags>"/bigobj"
+    <toolset>intel-win:<cxxflags>"/bigobj"
+    <local-visibility>hidden
+    : default-build
+    <warnings>extra
     ;
 
 alias cxx14 :

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -30,6 +30,13 @@ project
       cxx14_constexpr cxx14_decltype_auto cxx14_generic_lambdas cxx14_return_type_deduction cxx11_user_defined_literals
       # list could go on...
     ]
+    <toolset>clang:<cxxflags>"-Wsign-compare -Wstrict-aliasing -fstrict-aliasing -Wvexing-parse -Wfloat-conversion"
+    <toolset>gcc:<cxxflags>"-Wsign-compare -Wstrict-aliasing -fstrict-aliasing -Wfloat-conversion"
+    <toolset>msvc:<cxxflags>"/bigobj"
+    <toolset>intel-win:<cxxflags>"/bigobj"
+    <local-visibility>hidden
+    : default-build
+    <warnings>extra
     ;
 
 # Check consistency of build systems


### PR DESCRIPTION
I do not know much about b2, but this was able to make a super project checkout and recreated the original issue, and this fix fixes it.

:robot: _AI text below_ :robot:

Fixes #425.

`<local-visibility>hidden` in the global project requirements leaks into the install targets that `boost-library` generates and breaks alternative selection when building the Boost superproject. The warning flags, `/bigobj`, and hidden visibility only matter when compiling tests and examples, so this moves all requirements (and the `<warnings>extra` default-build) into `test/Jamfile` and `examples/Jamfile`, leaving `project /boost/histogram ;` as suggested in the issue.

The hidden-visibility setting dates back to #361, where it was added so the tests compile the way Python-wheel builds do; keeping it in the test/example projects preserves that.

Verified in a fresh superproject checkout: `b2 -n libs/histogram//install-libraries-shared` reproduces the `no match: <local-visibility>hidden` output before the change (also on macOS) and resolves cleanly after; test compiles still get `-fvisibility=hidden -fvisibility-inlines-hidden`, and `test//minimal` passes.