### PR TITLE
ci: quote GITHUB_BASE_REF and fall back to GITHUB_REF_NAME

### DIFF
--- a/.github/workflows/cov.yml
+++ b/.github/workflows/cov.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Fetch Boost superproject
       run: |
         cd ..
-        git clone -b $GITHUB_BASE_REF --depth 5 https://github.com/boostorg/boost.git
+        git clone -b "${GITHUB_BASE_REF:-$GITHUB_REF_NAME}" --depth 5 https://github.com/boostorg/boost.git
         cd boost
         mv -f $GITHUB_WORKSPACE/* libs/histogram
         git submodule update --init --depth 5 tools/build tools/boostdep

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Fetch Boost superproject
       run: |
         cd ..
-        git clone -b $GITHUB_BASE_REF --depth 5 https://github.com/boostorg/boost.git
+        git clone -b "${GITHUB_BASE_REF:-$GITHUB_REF_NAME}" --depth 5 https://github.com/boostorg/boost.git
         cd boost
         mv -f $GITHUB_WORKSPACE/* libs/histogram
         git submodule update --init --depth 5 tools/build tools/boostdep tools/quickbook tools/boostbook

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Fetch Boost superproject
       run: |
         cd ..
-        git clone -b $GITHUB_BASE_REF --depth 5 https://github.com/boostorg/boost.git
+        git clone -b "${GITHUB_BASE_REF:-$GITHUB_REF_NAME}" --depth 5 https://github.com/boostorg/boost.git
         cd boost
         mv -f $GITHUB_WORKSPACE/* libs/histogram
         git submodule update --init --depth 5 tools/build tools/boostdep
@@ -55,7 +55,7 @@ jobs:
     - name: Fetch Boost superproject
       run: |
         cd ..
-        git clone -b $GITHUB_BASE_REF --depth 5 https://github.com/boostorg/boost.git
+        git clone -b "${GITHUB_BASE_REF:-$GITHUB_REF_NAME}" --depth 5 https://github.com/boostorg/boost.git
         cd boost
         mv -f $GITHUB_WORKSPACE/* libs/histogram
         git submodule update --init --depth 5 tools/build tools/boostdep
@@ -76,7 +76,7 @@ jobs:
     - name: Fetch Boost superproject
       run: |
         cd ..
-        git clone -b $GITHUB_BASE_REF --depth 5 https://github.com/boostorg/boost.git
+        git clone -b "${GITHUB_BASE_REF:-$GITHUB_REF_NAME}" --depth 5 https://github.com/boostorg/boost.git
         cd boost
         mv -f $GITHUB_WORKSPACE/* libs/histogram
         git submodule update --init --depth 5 tools/build tools/boostdep

--- a/.github/workflows/superproject_cmake.yml
+++ b/.github/workflows/superproject_cmake.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Fetch Boost superproject
       run: |
         cd ..
-        git clone -b $GITHUB_BASE_REF --depth 5 https://github.com/boostorg/boost.git
+        git clone -b "${GITHUB_BASE_REF:-$GITHUB_REF_NAME}" --depth 5 https://github.com/boostorg/boost.git
         cd boost
         git submodule update --init --depth 5
         rm -rf libs/histogram/*


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`GITHUB_BASE_REF` is only set for `pull_request` events. On push builds (`superproject_cmake.yml`) it is empty, so `-b` consumed `--depth` and the clone failed. All six superproject clone lines now use `"${GITHUB_BASE_REF:-$GITHUB_REF_NAME}"`: PR builds keep using the base branch, and push builds fall back to the pushed branch (`master`/`develop`), which matches the superproject branch names.

Fixes #424