### PR TITLE
fix: lower CMake requirement to 3.10, raise policy max to 4.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 
-# We support CMake 3.12, but prefer 3.27 policies and behavior
-cmake_minimum_required(VERSION 3.12...3.27)
+# We support CMake 3.10, but prefer 4.4 policies and behavior
+cmake_minimum_required(VERSION 3.10...4.4)
 
 project(boost_histogram VERSION "${BOOST_SUPERPROJECT_VERSION}" LANGUAGES CXX)
 
@@ -27,6 +27,11 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   # Standalone build, fetch dependencies
 
   # Fetch support files
+
+  # BoostFetch.cmake still uses FetchContent_Populate, an error under CMP0169 NEW
+  if(POLICY CMP0169)
+    cmake_policy(SET CMP0169 OLD)
+  endif()
 
   message(STATUS "Fetching BoostFetch.cmake")
 
@@ -84,7 +89,12 @@ if (BUILD_TESTING)
   # do not pollute the superproject with the benchmarks
   if(NOT BOOST_SUPERPROJECT_VERSION)
 
-    add_subdirectory(benchmark)
+    # google/benchmark requires CMake 3.13
+    if(CMAKE_VERSION VERSION_LESS 3.13)
+      message(STATUS "CMake 3.13+ required by google/benchmark; skipping benchmarks")
+    else()
+      add_subdirectory(benchmark)
+    endif()
 
   endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,15 +2,20 @@
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 
-find_package(Python3 COMPONENTS Interpreter)
-if (Python3_FOUND)
-  # checks that b2 and cmake are in sync
-  add_test(NAME runpy-${PROJECT_NAME}_check_build_system COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_build_system.py)
-
-  # checks that all headers are included in odr test
-  add_test(NAME runpy-${PROJECT_NAME}_check_odr_test COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_odr_test.py)
+# FindPython3 requires CMake 3.12
+if (CMAKE_VERSION VERSION_LESS 3.12)
+  message(STATUS "CMake 3.12+ required to check for odr violations and build system consistency")
 else()
-MESSAGE(WARNING "Python interpreter not found, cannot check for odr violations and build system consistency")
+  find_package(Python3 COMPONENTS Interpreter)
+  if (Python3_FOUND)
+    # checks that b2 and cmake are in sync
+    add_test(NAME runpy-${PROJECT_NAME}_check_build_system COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_build_system.py)
+
+    # checks that all headers are included in odr test
+    add_test(NAME runpy-${PROJECT_NAME}_check_odr_test COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_odr_test.py)
+  else()
+    message(WARNING "Python interpreter not found, cannot check for odr violations and build system consistency")
+  endif()
 endif()
 
 include(BoostTest OPTIONAL RESULT_VARIABLE HAVE_BOOST_TEST)


### PR DESCRIPTION
Getting 3.10 on macOS ARM was "fun". Finally just used a docker container.

:robot: _AI text below_ :robot:

Fixes #417.

FindPython3 (added in CMake 3.12) was the only thing that needed 3.12. On older CMake, the two Python consistency checks are skipped with a status message; they still run in CI. Two more changes surfaced while testing the full range:

- google/benchmark requires CMake 3.13, so standalone builds on older CMake skip the benchmarks.
- With the policy max at 4.4, CMP0169 makes `FetchContent_Populate` in BoostFetch.cmake an error, so the standalone path sets it to OLD.

Verified the standalone configure/build/ctest on CMake 3.10.2 (Ubuntu 18.04 container) and 4.4.0 (macOS).