### PR TITLE
fix: swapped modf outputs in circular variable::value()

### DIFF
--- a/include/boost/histogram/axis/variable.hpp
+++ b/include/boost/histogram/axis/variable.hpp
@@ -210,8 +210,9 @@ public:
     if (options_type::test(option::circular)) {
       auto shift = std::floor(i / size());
       i -= shift * size();
-      double z;
-      const auto k = static_cast<index_type>(std::modf(i, &z));
+      double whole;
+      const double z = std::modf(i, &whole);
+      const auto k = static_cast<index_type>(whole);
       const auto a = vec_[0];
       const auto b = vec_[size()];
       return (1.0 - z) * vec_[k] + z * vec_[k + 1] + shift * (b - a);

--- a/test/axis_variable_test.cpp
+++ b/test/axis_variable_test.cpp
@@ -123,6 +123,21 @@ int main() {
     BOOST_TEST_EQ(a.index(4), 1); // 4 - 3 = 1
   }
 
+  // axis::variable circular with size > 2 and non-equidistant bins;
+  // the error in value() cancels for size == 2 and integer arguments
+  {
+    axis::variable<double, axis::null_type, op::circular_t> a{0, 1, 3, 4};
+    BOOST_TEST_EQ(a.value(-1), -1); // vec_[2] - period
+    BOOST_TEST_EQ(a.value(0), 0);
+    BOOST_TEST_EQ(a.value(1), 1);
+    BOOST_TEST_EQ(a.value(2), 3);
+    BOOST_TEST_EQ(a.value(3), 4);
+    BOOST_TEST_EQ(a.value(4), 5);
+    BOOST_TEST_EQ(a.value(0.5), 0.5);
+    BOOST_TEST_EQ(a.value(1.5), 2);
+    BOOST_TEST_EQ(a.value(2.5), 3.5);
+  }
+
   // axis::regular with growth
   {
     using pii_t = std::pair<axis::index_type, axis::index_type>;


### PR DESCRIPTION
From #437.

:robot: _AI text below_ :robot:

`std::modf` returns the fractional part and stores the whole part in its output argument. The circular branch of `variable::value()` used the return value as the bin index `k` and the whole part as the interpolation weight `z` — exactly swapped. Every fractional index, and every integer index on a non-equidistant circular axis with more than two bins, returned a point on the line through the first two edges instead of the correct edge, so `bin(i).lower()/upper()/center()` and the printed representation were wrong.

The error cancels for size-2 axes with integer arguments, which is all the existing test covered. Added a size-3 non-equidistant regression test (fails with 5 wrong values before the fix) and fixed the variable use.