### PR TITLE
fix: do not create map cells when adding or subtracting zero

### DIFF
--- a/include/boost/histogram/storage_adaptor.hpp
+++ b/include/boost/histogram/storage_adaptor.hpp
@@ -171,8 +171,9 @@ struct map_impl : T {
       if (it != static_cast<T*>(map)->end()) {
         it->second += u;
       } else {
-        auto pair = map->emplace(idx, value_type{});
-        pair.first->second += u;
+        value_type tmp{};
+        tmp += u;
+        if (!(tmp == value_type{})) map->emplace(idx, tmp);
       }
       return *this;
     }
@@ -184,8 +185,9 @@ struct map_impl : T {
       if (it != static_cast<T*>(map)->end()) {
         it->second -= u;
       } else {
-        auto pair = map->emplace(idx, value_type{});
-        pair.first->second -= u;
+        value_type tmp{};
+        tmp -= u;
+        if (!(tmp == value_type{})) map->emplace(idx, tmp);
       }
       return *this;
     }

--- a/test/storage_adaptor_test.cpp
+++ b/test/storage_adaptor_test.cpp
@@ -211,6 +211,23 @@ int main() {
     BOOST_TEST(std::isnan(static_cast<double>(a[1])));
   }
 
+  // adding or subtracting zero must not create cells in map-based storage_adaptor
+  {
+    using map_t = std::map<std::size_t, double>;
+    auto a = storage_adaptor<map_t>();
+    a.reset(4);
+    a[0] += 0;
+    a[1] -= 0;
+    BOOST_TEST_EQ(static_cast<const map_t&>(a).size(), 0);
+    BOOST_TEST_EQ(a[0], 0);
+    BOOST_TEST_EQ(a[1], 0);
+    a[2] += 1;
+    a[3] -= 1;
+    BOOST_TEST_EQ(static_cast<const map_t&>(a).size(), 2);
+    BOOST_TEST_EQ(a[2], 1);
+    BOOST_TEST_EQ(a[3], -1);
+  }
+
   // with accumulators::weighted_sum
   {
     auto a = storage_adaptor<std::vector<accumulators::weighted_sum<double>>>();


### PR DESCRIPTION
`map_impl::reference::operator+=` and `operator-=` emplaced a cell for a missing index even when the result stayed as default `value_type{}`. Compute the result in a temporary and emplace only if it is non-default, as `operator/=` already does.

First half of #440, the simple fix.

Assisted-by: ClaudeCode:claude-opus-5
