### PR TITLE
[doc] Fix the template parameter names in three Doxygen blocks

### DIFF
--- a/include/boost/histogram/accumulators/count.hpp
+++ b/include/boost/histogram/accumulators/count.hpp
@@ -35,7 +35,7 @@ namespace accumulators {
   estimate for the weight distribution should be computed as well (generally needed for a
   detailed statistical analysis), use `accumulators::weighted_sum`.
 
-  @tparam T C++ builtin arithmetic type (integer or floating point).
+  @tparam ValueType C++ builtin arithmetic type (integer or floating point).
   @tparam ThreadSafe Set to true to make increments and adds thread-safe.
 */
 template <class ValueType, bool ThreadSafe>

--- a/include/boost/histogram/sample.hpp
+++ b/include/boost/histogram/sample.hpp
@@ -17,7 +17,7 @@ namespace histogram {
 
   You should not construct these directly, use the sample() helper function.
 
-  @tparam Underlying type.
+  @tparam T Underlying type.
 */
 template <class T>
 struct sample_type {

--- a/include/boost/histogram/weight.hpp
+++ b/include/boost/histogram/weight.hpp
@@ -16,7 +16,7 @@ namespace histogram {
 
   You should not construct these directly, use the weight() helper function.
 
-  @tparam Underlying arithmetic type.
+  @tparam T Underlying arithmetic type.
 */
 template <class T>
 struct weight_type {


### PR DESCRIPTION
Three Doxygen blocks name a template parameter the declaration does not have. Comments only.

**`accumulators/count.hpp`**

```
  @tparam T C++ builtin arithmetic type (integer or floating point).
  @tparam ThreadSafe Set to true to make increments and adds thread-safe.
*/
template <class ValueType, bool ThreadSafe>
class count {
```

`ThreadSafe` is right, `T` should be `ValueType`.

**`weight.hpp` and `sample.hpp`**

```
  @tparam Underlying arithmetic type.
*/
template <class T>
struct weight_type {
```

"Underlying" reads as an adjective here, but Doxygen takes the first word after `@tparam` as the name, so it documents a parameter called `Underlying` and reports `T` as undocumented. Inserting the name leaves the sentence as it was: `@tparam T Underlying arithmetic type.` Same in `sample.hpp`.

I checked the rest of `accumulators/` and `axis/` for the same thing; `count.hpp` is the only one there, the axis blocks all match their declarations.

## Not included

A sweep of the whole library also flags `axis/traits.hpp`, `histogram.hpp`, `indexed.hpp`, `unsafe_access.hpp` and the five `utility/*_interval.hpp` headers, but every one of those is my parser failing on `auto&&` parameters and on `operator()`, not a real mismatch — I read them and the docs are correct. Mentioning it so nobody repeats the check and thinks there is more here.
